### PR TITLE
Add Skillcheck Cloud dashboard + CLI run metering; fix trial-collapse…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ site/node_modules/
 packages/site/.next/
 packages/site/out/
 packages/site/node_modules/
+.vercel/
+dashboard/.vercel/
 .DS_Store

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,670 @@
+---
+version: alpha
+name: HP-design-analysis
+description: An inspired interpretation of HP's design language — a white-paper enterprise-consumer system anchored by HP Electric Blue (`#024ad8`) as the lone signal CTA, near-black ink (`#1a1a1a`) for headlines, geometric Forma-DJR sans throughout, and angular blue-chevron decorations that nod to the HP wordmark's slashes. Cards round at 8–16px, photos sit in soft 16px frames, and dark navy slabs anchor the customer-story and "how can we help" closing bands.
+
+colors:
+  primary: "#024ad8"
+  primary-bright: "#296ef9"
+  primary-deep: "#0e3191"
+  primary-soft: "#c9e0fc"
+  on-primary: "#ffffff"
+  ink: "#1a1a1a"
+  ink-deep: "#000000"
+  ink-soft: "#292929"
+  on-ink: "#ffffff"
+  canvas: "#ffffff"
+  paper: "#ffffff"
+  cloud: "#f7f7f7"
+  fog: "#e8e8e8"
+  steel: "#c2c2c2"
+  graphite: "#636363"
+  charcoal: "#3d3d3d"
+  hairline: "#e8e8e8"
+  hairline-strong: "#c2c2c2"
+  link: "#024ad8"
+  link-pressed: "#0e3191"
+  bloom-coral: "#ff5050"
+  bloom-rose: "#f9d4d2"
+  bloom-deep: "#b3262b"
+  bloom-wine: "#5a1313"
+  storm-mist: "#8ebdce"
+  storm-sea: "#7fadbe"
+  storm-deep: "#356373"
+  error: "#b3262b"
+
+typography:
+  display-xxl:
+    fontFamily: Forma DJR Micro
+    fontSize: 72px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: 0
+  display-xl:
+    fontFamily: Forma DJR Micro
+    fontSize: 56px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: 0
+  display-lg:
+    fontFamily: Forma DJR Micro
+    fontSize: 44px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: 0
+  display-md:
+    fontFamily: Forma DJR Micro
+    fontSize: 32px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: 0
+  display-sm:
+    fontFamily: Forma DJR Micro
+    fontSize: 24px
+    fontWeight: 500
+    lineHeight: 1.17
+    letterSpacing: 0
+  display-xs:
+    fontFamily: Forma DJR Micro
+    fontSize: 20px
+    fontWeight: 500
+    lineHeight: 1.0
+    letterSpacing: 0
+  body-lg:
+    fontFamily: Forma DJR Micro
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.33
+    letterSpacing: 0
+  body-md:
+    fontFamily: Forma DJR Micro
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.38
+    letterSpacing: 0
+  body-emphasis:
+    fontFamily: Forma DJR Micro
+    fontSize: 16px
+    fontWeight: 500
+    lineHeight: 1.38
+    letterSpacing: 0
+  caption-md:
+    fontFamily: Forma DJR Micro
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+  caption-sm:
+    fontFamily: Forma DJR Micro
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.33
+    letterSpacing: 0
+  caption-bold:
+    fontFamily: Forma DJR Micro
+    fontSize: 14px
+    fontWeight: 700
+    lineHeight: 1.3
+    letterSpacing: 0
+  link-md:
+    fontFamily: Forma DJR Micro
+    fontSize: 16px
+    fontWeight: 500
+    lineHeight: 1.38
+    letterSpacing: 0
+  button-md:
+    fontFamily: Forma DJR Micro
+    fontSize: 14px
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: 0.7px
+    textTransform: uppercase
+  button-sm:
+    fontFamily: Forma DJR Micro
+    fontSize: 12.6px
+    fontWeight: 700
+    lineHeight: 1.0
+    letterSpacing: 0.126px
+  price-md:
+    fontFamily: Forma DJR Micro
+    fontSize: 24px
+    fontWeight: 500
+    lineHeight: 1.17
+    letterSpacing: 0
+
+rounded:
+  none: 0px
+  xs: 2px
+  sm: 3px
+  md: 4px
+  lg: 8px
+  xl: 16px
+  pill: 9999px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 20px
+  xl: 24px
+  xxl: 32px
+  section: 80px
+
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 24px
+    height: 44px
+  button-primary-pressed:
+    backgroundColor: "{colors.primary-deep}"
+    textColor: "{colors.on-primary}"
+  button-primary-disabled:
+    backgroundColor: "{colors.steel}"
+    textColor: "{colors.on-primary}"
+  button-ink:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 24px
+    height: 44px
+  button-outline:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.primary}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 24px
+    height: 44px
+  button-outline-ink:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 24px
+    height: 44px
+  button-text-link:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.primary}"
+    typography: "{typography.link-md}"
+    padding: 4px 0
+  badge-pill-ink:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 6px 12px
+  badge-pill-outline:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 6px 12px
+  badge-sale-coral:
+    backgroundColor: "{colors.bloom-coral}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.caption-bold}"
+    rounded: "{rounded.sm}"
+    padding: 4px 8px
+  text-input:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 16px
+    height: 44px
+  text-input-focused:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+  text-input-search:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 16px
+    height: 40px
+  card-product:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  card-product-feature:
+    backgroundColor: "{colors.cloud}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  card-pricing-tier:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  card-pricing-tier-featured:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  card-customer-story:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 16px
+  card-article-tile:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 16px
+  card-category-icon:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-emphasis}"
+    rounded: "{rounded.lg}"
+    padding: 16px
+  promo-strip-dark:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xl}"
+    padding: 48px
+  hero-promo-card:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: 32px
+  utility-strip:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.caption-md}"
+    height: 36px
+    padding: 0 24px
+  nav-bar-top:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    height: 64px
+    padding: 0 32px
+  nav-link:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    padding: 8px 16px
+  category-tab:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-emphasis}"
+    rounded: "{rounded.pill}"
+    padding: 8px 20px
+  category-tab-active:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.pill}"
+  faq-row:
+    backgroundColor: "{colors.canvas}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-emphasis}"
+    rounded: "{rounded.lg}"
+    padding: 20px 24px
+  chevron-decoration:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    rounded: "{rounded.none}"
+  help-band-dark:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-md}"
+    padding: 64px 32px
+  footer-dark:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-md}"
+    padding: 64px 32px
+---
+
+## Overview
+
+HP reads like a long-running consumer-electronics catalog crossed with an enterprise-software product page. The whole system sits on **pure white** (`{colors.canvas}` — `#ffffff`) with thin gray panels (`{colors.cloud}` / `{colors.fog}`) for alternating section bands. There is one chromatic action color — **HP Electric Blue** (`{colors.primary}` — `#024ad8`) — and one ink color (`{colors.ink}` — `#1a1a1a`); together they do ninety percent of the work. Type is a single family across every surface: **Forma DJR Micro**, HP's bespoke geometric grotesque, set at weight 500 for headlines and 400 for body — clean, neutral, slightly mechanical.
+
+The signature gesture is **angular blue chevrons** — sharp 0-radius slashes derived from the HP wordmark's pair of parallel slashes — that anchor the homepage hero, the laptop-page hero, and the printer pricing page. They appear on the left and right edges of the primary banner card, layered behind product photography. Outside those decorative slashes, every other surface is rectilinear with **soft 8–16px corners** on cards and a 4px corner on buttons.
+
+The system breaks into three voice modes: a **white commercial body** for product browsing (cards, category icons, pricing tiers); a **dark navy slab** (`{colors.ink}` near-black) for testimonial bands, the closing "How can we help?" footer-prelude, and the page footer; and a **light fog band** (`{colors.cloud}` / `{colors.fog}`) for utility sections like comparison strips and FAQ accordions. The blue accent appears only on filled CTAs, link text, the chevron decorations, and the active price-stamp on a featured tier — never as a section background.
+
+**Key Characteristics:**
+- Pure white canvas (`{colors.canvas}`) with deep ink (`{colors.ink}`) running every body surface; light fog bands (`{colors.cloud}`, `{colors.fog}`) alternate for section rhythm
+- HP Electric Blue (`{colors.primary}`) is the lone CTA fill and link color; it appears at most twice per viewport
+- Bespoke Forma DJR Micro across every surface — display, body, button, caption — at weights 400 / 500 / 600 / 700
+- Cards round at `{rounded.xl}` (16px) for product/pricing tiles; buttons sit at `{rounded.md}` (4px) with capitalize labels
+- Geometric blue chevrons (`{colors.primary}` rectangles cut at 45°) frame hero photography and reinforce the wordmark
+- Dark-navy slabs (`{colors.ink}`) close every page rhythm — testimonial bands, "how can we help?" prelude, and the footer
+- Section rhythm: utility-strip → top nav → white body → cloud-band → ink slab → cloud-band → ink footer
+
+## Colors
+
+> **No Interaction sub-section.** Hover colors are silently filtered. Allowed sub-sections: Brand & Accent, Surface, Text, Semantic.
+
+### Brand & Accent
+- **HP Electric Blue** (`{colors.primary}` — `#024ad8`): the system's lone signal — primary CTA fill, link color, chevron-decoration fill, active sub-nav indicator. Reserved.
+- **Bright Blue** (`{colors.primary-bright}` — `#296ef9`): a slightly lighter variant used inside dark slabs (testimonial-card buttons, dark-band CTA links) where the deeper blue would muddy.
+- **Deep Navy** (`{colors.primary-deep}` — `#0e3191`): pressed state for the primary CTA and the visited-link color.
+- **Soft Blue** (`{colors.primary-soft}` — `#c9e0fc`): pale-blue surface used inside customer-story cards and selection chips.
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `#ffffff`): the universal page background. White, full opacity.
+- **Paper** (`{colors.paper}` — `#ffffff`): card surfaces — same white as canvas, with hairline borders or shadows providing the lift.
+- **Cloud** (`{colors.cloud}` — `#f7f7f7`): the lightest gray section band, used for alternating-row backgrounds and product-feature card groups.
+- **Fog** (`{colors.fog}` — `#e8e8e8`): a slightly darker gray surface band, used for FAQ outer panels and the "Trending laptops" header strip.
+- **Steel** (`{colors.steel}` — `#c2c2c2`): hairline border used on outlined elements with stronger emphasis (focus states, active filter).
+- **Bloom Coral / Bloom Rose** (`{colors.bloom-coral}` / `{colors.bloom-rose}` — `#ff5050`, `#f9d4d2`): the "Get 25% off" sale-tag chip + soft pink lifestyle accent on the sale hero.
+- **Storm Mist / Sea / Deep** (`{colors.storm-mist}`, `{colors.storm-sea}`, `{colors.storm-deep}` — `#8ebdce`, `#7fadbe`, `#356373`): the teal-storm tones reserved for the printer-plan illustration backdrop and supporting infographic accents.
+
+### Text
+- **Ink** (`{colors.ink}` — `#1a1a1a`): the universal text color on white surfaces — headlines, body, button labels, navigation.
+- **Ink Deep** (`{colors.ink-deep}` — `#000000`): pure black used for the wordmark and 1px hairline strokes around badge outlines.
+- **Ink Soft** (`{colors.ink-soft}` — `#292929`): an alternate near-black used inside dark-navy slabs as a subtle textural shift.
+- **On Ink** (`{colors.on-ink}` — `#ffffff`): pure white used for headline and body text on every dark-navy slab.
+- **Charcoal** (`{colors.charcoal}` — `#3d3d3d`): muted body color on white surfaces — secondary descriptions, fine-print disclaimers.
+- **Graphite** (`{colors.graphite}` — `#636363`): smaller-print color, used for legal lines and timestamp metadata.
+
+### Semantic
+- **Bloom Deep** (`{colors.bloom-deep}` — `#b3262b`) + **Bloom Wine** (`{colors.bloom-wine}` — `#5a1313`): error and discount-emphasis colors. The deep brick reads as "sale" or "destructive" depending on placement.
+- **Storm Deep** (`{colors.storm-deep}` — `#356373`): used as a neutral status accent (e.g., printer-plan tier "Versatile" tier color).
+
+## Typography
+
+### Font Family
+
+The voice is **single-family**: Forma DJR Micro (HP's bespoke geometric grotesque, fallback Arial) across every surface — display, body, button, caption. Forma DJR Micro is a wide, slightly rounded grotesque designed at small optical sizes to stay legible at UI-chrome scale. HP runs it at weight 400 for body, 500 for display headlines, 600/700 for emphasis and button labels.
+
+The 16/14/12-px caption tier carries the catalog metadata — model numbers, spec rows, fine print — at weight 400 with a 1.4–1.5 line-height. Button labels lift to weight 600/700 with positive 0.5–1.1px letter-spacing and uppercase transform — the only place the system tracks letters.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xxl}` | 72px | 500 | 1.0 | 0 | Hero headline (homepage, laptop hub) |
+| `{typography.display-xl}` | 56px | 500 | 1.0 | 0 | Section headlines on landing pages |
+| `{typography.display-lg}` | 44px | 500 | 1.0 | 0 | Sub-section headlines on shop pages |
+| `{typography.display-md}` | 32px | 500 | 1.0 | 0 | Promo strip headlines, FAQ section headers |
+| `{typography.display-sm}` | 24px | 500 | 1.17 | 0 | Card titles, pricing-tier names |
+| `{typography.display-xs}` | 20px | 500 | 1.0 | 0 | Inline list headers, accordion labels |
+| `{typography.body-lg}` | 18px | 400 | 1.33 | 0 | Lead paragraphs |
+| `{typography.body-md}` | 16px | 400 | 1.38 | 0 | Default body |
+| `{typography.body-emphasis}` | 16px | 500 | 1.38 | 0 | Bolded run-in copy |
+| `{typography.caption-md}` | 14px | 400 | 1.5 | 0 | Specs, metadata, captions |
+| `{typography.caption-bold}` | 14px | 700 | 1.3 | 0 | Sale tags, in-card highlights |
+| `{typography.caption-sm}` | 12px | 400 | 1.33 | 0 | Footnotes, legal lines |
+| `{typography.link-md}` | 16px | 500 | 1.38 | 0 | Inline link emphasis |
+| `{typography.button-md}` | 14px | 600 | 1.4 | 0.7px | Primary/secondary button labels (uppercase) |
+| `{typography.button-sm}` | 12.6px | 700 | 1.0 | 0.126px | Compact button labels in tight cells |
+| `{typography.price-md}` | 24px | 500 | 1.17 | 0 | Tier and product price stamps |
+
+### Principles
+
+The typographic decision worth flagging: HP runs **weight 500 for every display size**, including the largest 72px hero headline. Most editorial systems jump to 600/700 at hero scale; HP doesn't. The result feels open and approachable rather than commanding — appropriate for a brand that sells across consumer, SMB, and enterprise audiences in the same catalog.
+
+Forma DJR Micro's rounded-grotesque shapes do most of the warmth. There's no italic in the system except inside legal disclaimers; emphasis is carried by weight (500 → body-emphasis, 700 → caption-bold) instead.
+
+### Note on Font Substitutes
+
+Forma DJR Micro is proprietary (Commercial Type / Mark Caneso). Closest open-source substitutes:
+- **Inter** at weights 400 / 500 / 600 / 700 — slightly narrower than Forma DJR Micro; bump font-size by ~3% to compensate
+- **Manrope** at weights 400 / 500 / 600 / 700 — closer in proportion, gentler curves; use directly with no metric adjustment
+- **Roboto** at weights 400 / 500 / 700 — flatter character; use as last-resort fallback
+
+When swapping, set body line-height to 1.4 and display line-height to 1.0 explicitly — the Forma DJR Micro line-height numbers are tight, and most substitutes default looser.
+
+## Layout
+
+### Spacing System
+
+- **Base unit**: 8px. Smaller half-step at 4px. The scale is gentle — most card padding lands at 16px or 24px; section gap at 80px.
+- **Tokens (front matter)**: `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 20px · `{spacing.xl}` 24px · `{spacing.xxl}` 32px · `{spacing.section}` 80px
+- **Section padding**: `{spacing.section}` (80px) vertical between major bands on desktop; collapses to ~48px on mobile.
+- **Card internal padding**: `{spacing.xl}` (24px) for product cards; `{spacing.xxl}` (32px) for promo strips and feature cards; `{spacing.md}` (16px) for compact article tiles.
+- **Gutter**: `{spacing.xl}` (24px) between grid columns at desktop; `{spacing.md}` (16px) on tablet/mobile.
+
+The 80px section gap is the universal rhythm constant — it appears between every major homepage band, between the hero and the comparison table on the printer-plan page, and between feature rows on the laptop-shop page.
+
+### Grid & Container
+
+- **Desktop max-width**: 1366px content container with full-bleed-on-canvas section backgrounds.
+- **Hero**: a single full-width photo card (homepage and laptop-hub hero) with the headline overlay positioned upper-left or upper-right.
+- **Product family grid**: 4 columns at >1200px, 3 at 1024–1199px, 2 at 768–1023px, 1 below 768px.
+- **Pricing tiers**: 4 columns at >1024px, 2x2 grid at 768–1023px, single-column accordion below 768px.
+- **Footer**: 5-column link grid at >1024px, collapsing to 2-column then accordion on mobile.
+
+### Whitespace Philosophy
+
+Whitespace is **commercial-clean** — generous around hero photography, tight around catalog spec rows. Product cards leave breathing room above and below the photo (≥32px) so the laptop or printer reads as a hero shot rather than a thumbnail. The fine-print disclaimer regions (legal, footnote rows) tighten line-height to 1.3 and shrink type to 11–12px so the bulk of fine print stays compact.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flat | No border, no shadow. | Section bands (white, cloud, fog), full-bleed photo heroes |
+| 1 — Hairline | 1px solid `{colors.hairline}` (`#e8e8e8`) border, no shadow. | Outlined buttons, comparison-table cells, FAQ accordion outers |
+| 2 — Soft Lift | `0 2px 8px rgba(26, 26, 26, 0.08)`. | Product cards, pricing-tier columns, customer-story tiles |
+| 3 — Floating Modal | `0 8px 24px rgba(26, 26, 26, 0.12)`. | Add-to-cart drawer, mobile-nav sheet, image zoom modal |
+
+The system is mostly flat — depth is communicated by **color contrast** (cloud-band vs. white card on the same band) rather than shadow elevation. The Soft Lift level is the workhorse for the catalog — every product tile and pricing column gets it; nothing else does. Modal-floating is rare and reserved for transient overlays.
+
+### Decorative Depth
+
+The system's most distinctive depth gesture is the **HP blue chevron pair** — two angular `{colors.primary}` slashes (no radius, no shadow) that sit on the left and right of the homepage hero card and the laptop-shop hero. They're not decorative noise; they're a literal echo of the HP wordmark's two parallel slashes, scaled up to architectural size. Treat them as a brand artifact, not a generic geometric flourish.
+
+Photography on the homepage and laptop-shop pages frames product imagery inside `{rounded.xl}` (16px) containers with a soft 1px hairline. Lifestyle photography (testimonials, "How HP works for X") sits full-bleed inside dark-navy slabs without rounding.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.none}` | 0px | Hero chevron decorations, full-bleed photo heroes, marquee strips |
+| `{rounded.xs}` | 2px | Secondary chip backgrounds, sale-tag pills |
+| `{rounded.sm}` | 3px | Default secondary CTA radius (small touch zones) |
+| `{rounded.md}` | 4px | Primary buttons, secondary buttons, text inputs |
+| `{rounded.lg}` | 8px | Badge pills, category-icon cards, FAQ row containers |
+| `{rounded.xl}` | 16px | Product cards, pricing tiers, customer-story tiles, photo frames |
+| `{rounded.pill}` | 9999px | Category sub-nav tabs, search-pill input, filter chips |
+
+The system maintains a clear two-tier philosophy: **buttons stay sharp** (4px, almost rectilinear) while **cards and photo frames stay soft** (16px). This split is the visual signature — sharp interactive elements against softer container surfaces.
+
+### Photography Geometry
+
+Hero photography sits in `{rounded.xl}` (16px) frames with no border. Product family thumbnails inside the laptop-grid are 1:1 (square) on a `{colors.canvas}` background, padded so the laptop is shown at ~70% of the frame. Customer-story photography uses 16:9 inside the same `{rounded.xl}` frame. There are no full-bleed circular avatars; testimonial avatars are 4px-rounded squares.
+
+## Components
+
+> **No hover states documented.** Every component spec below documents only Default and Active/Pressed states. Variants live as separate front-matter entries.
+
+### Buttons
+
+**`button-primary`** — the lone HP Electric Blue CTA
+- Background `{colors.primary}`, text `{colors.on-primary}`, type `{typography.button-md}` (uppercase, 0.7px tracking), padding `{spacing.sm} {spacing.xl}` (12 × 24), height 44px, rounded `{rounded.md}`
+- Pressed state `button-primary-pressed` — background `{colors.primary-deep}`, same text
+- Disabled state `button-primary-disabled` — background `{colors.steel}`, white text
+- Used for: "Buy now", "Shop now", "Get a printer", primary form submit
+
+**`button-ink`** — black filled CTA
+- Background `{colors.ink}`, text `{colors.on-primary}`, padding `{spacing.sm} {spacing.xl}`, height 44px, rounded `{rounded.md}`, type `{typography.button-md}`
+- Used for: "Buy now" on dark photo overlays, secondary primary actions where the blue would clash with imagery
+
+**`button-outline`** — blue-text outlined CTA
+- Background `{colors.canvas}`, text `{colors.primary}`, 1px `{colors.primary}` border, padding `{spacing.sm} {spacing.xl}`, height 44px, rounded `{rounded.md}`
+- Used for: "Compare", "Customize", "Learn more" — secondary actions on white surfaces
+
+**`button-outline-ink`** — black-text outlined CTA
+- Background `{colors.canvas}`, text `{colors.ink}`, 1px `{colors.ink}` border, padding `{spacing.sm} {spacing.xl}`, height 44px, rounded `{rounded.md}`
+- Used for: "View" buttons inside product family card grids — neutral against the blue primary
+
+**`button-text-link`** — inline blue link with underline
+- Background `{colors.canvas}`, text `{colors.primary}`, type `{typography.link-md}`, padding `{spacing.xxs} 0`
+- Used for: "See details", "Read more" inside cards and disclaimer rows
+
+### Cards & Containers
+
+**`card-product`** — the workhorse product tile
+- Background `{colors.canvas}`, rounded `{rounded.xl}` (16px), padding `{spacing.xl}` (24px), Soft Lift shadow
+- Layout: hero photo (1:1 ratio) on top, title in `{typography.display-xs}`, spec rows in `{typography.caption-md}`, price in `{typography.price-md}`, CTA pinned to bottom
+- Used for: laptop catalog cards, desktop catalog cards
+
+**`card-product-feature`** — full-row feature card with photo + copy
+- Background `{colors.cloud}`, rounded `{rounded.xl}`, padding `{spacing.xxl}` (32px)
+- Layout: photo on the left (50% width), copy on the right with section eyebrow + title + body + CTA pair
+- Used for: "Trending laptops" feature rows, "Shop these must haves"
+
+**`card-pricing-tier`** + **`card-pricing-tier-featured`**
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xl}`, Soft Lift shadow
+- Tier name in `{typography.display-sm}`, monthly price in `{typography.display-md}` with `{typography.caption-md}` cadence, page count caption, full feature list, primary CTA
+- Featured tier carries `{colors.primary}` text accent on the price-stamp + a `{colors.primary}` thin top border instead of a colored card background — never inverted to dark
+
+**`card-customer-story`** — the three-up testimonial tile
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.md}` (16px), Soft Lift shadow
+- 16:9 photo at top in `{rounded.xl}` frame, quote excerpt in `{typography.body-md}`, attribution row at the bottom
+- Used in the "See what our customers say" homepage section
+
+**`card-article-tile`** — the four-up "Latest from HP" tile
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.md}`, Soft Lift shadow
+- 16:9 thumbnail at top, date eyebrow in `{typography.caption-sm}`, title in `{typography.body-emphasis}`, "Read more" link
+
+**`card-category-icon`** — the small icon-and-label card in the homepage "Our Products" row
+- Background `{colors.canvas}`, rounded `{rounded.lg}` (8px), padding `{spacing.md}`
+- 48px icon at top, label in `{typography.body-emphasis}` below
+- Used for: Laptops, Desktops, Printers, Computer Tools, Accessories, Enterprise Solutions
+
+**`hero-promo-card`** — the homepage hero card with chevron decorations
+- Background `{colors.canvas}`, rounded `{rounded.xl}`, padding `{spacing.xxl}` (32px)
+- Photography occupies left half; copy block (eyebrow + headline + price stamp + CTA pair) occupies right half
+- Flanked by `chevron-decoration` blue slashes outside the card's bounding box on left and right edges
+
+**`promo-strip-dark`** — the inline dark navy promo block
+- Background `{colors.ink}`, text `{colors.on-ink}`, rounded `{rounded.xl}`, padding `{spacing.xxl} 48px`
+- Used for: "When did work start getting in the way of work?" mid-page promo, the SMB testimonial slab
+
+### Inputs & Forms
+
+**`text-input`** + **`text-input-focused`**
+- Background `{colors.canvas}`, text `{colors.ink}`, rounded `{rounded.md}`, padding `{spacing.sm} {spacing.md}`, height 44px
+- 1px `{colors.steel}` border in default; gains 1px `{colors.ink}` border on focus (no halo)
+
+**`text-input-search`** — pill search in the top nav
+- Background `{colors.canvas}`, rounded `{rounded.md}`, padding `{spacing.sm} {spacing.md}`, height 40px, 1px `{colors.steel}` border, magnifying-glass icon at right
+
+**`badge-pill-ink`** — filled tag pill
+- Background `{colors.ink}`, text `{colors.on-primary}`, rounded `{rounded.lg}`, padding 6px 12px, type `{typography.body-md}`
+- Used inline next to product titles to mark "New" or featured indicators
+
+**`badge-pill-outline`** — outlined tag pill
+- Background `{colors.canvas}`, text `{colors.ink}`, 1px `{colors.ink}` border, rounded `{rounded.lg}`, padding 6px 12px
+
+**`badge-sale-coral`** — the sale price-stamp
+- Background `{colors.bloom-coral}`, text `{colors.on-primary}`, rounded `{rounded.sm}`, padding `{spacing.xxs} {spacing.xs}`, type `{typography.caption-bold}`
+- Used for: "Save $200", "25% off" overlay tags on hero promo cards
+
+### Navigation
+
+**`utility-strip`** — the top-of-page utility bar
+- Background `{colors.ink}`, text `{colors.on-primary}`, height 36px, padding 0 {spacing.xl}, type `{typography.caption-md}`
+- Holds: country/locale picker, "For Business / For Home" toggle, "Sign in" link, cart link
+
+**`nav-bar-top`** — desktop top nav (sits below utility strip)
+- Background `{colors.canvas}`, height 64px, padding 0 32px
+- Layout: HP wordmark logo flush left → middle category list (Laptops / Desktops / Printers / Accessories / Solutions / Support) → right slot with Search field, Sign-in link, Cart icon
+- 1px `{colors.hairline}` bottom border separates nav from page
+
+**`nav-link`**
+- Background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-md}`, padding `{spacing.xs} {spacing.md}`
+- Active page draws a 2px `{colors.primary}` underline below the text baseline
+
+**Top Nav (Mobile)**
+- Same height, hamburger icon replaces the middle category list, Search and Cart stay visible
+- Drawer expands as a full-canvas sheet with `{typography.body-lg}` link list and a sticky Sign-in CTA at bottom
+
+**`category-tab`** + **`category-tab-active`** — the pill sub-nav
+- Default: background `{colors.canvas}`, text `{colors.ink}`, type `{typography.body-emphasis}`, rounded `{rounded.pill}`, padding `{spacing.xs} {spacing.lg}`
+- Active: background `{colors.ink}`, text `{colors.on-primary}`, same rounding
+- Used on the laptop-shop page for "All / Trending / On Sale" filtering, and on the homepage "How can we help?" closing band
+
+### Signature Components
+
+**`chevron-decoration`** — the geometric blue slash motif
+- Background `{colors.primary}`, rounded `{rounded.none}`, no shadow
+- Renders as a sharp parallelogram cut at ~60° angle, sized to the height of the hero card it flanks
+- Reserved for hero bands and full-page banners — never decorative noise inside cards
+
+**`faq-row`** — the accordion row on the printer-plan FAQ
+- Background `{colors.canvas}`, rounded `{rounded.lg}`, padding `{spacing.lg} {spacing.xl}`, type `{typography.body-emphasis}`
+- 1px `{colors.hairline}` divider between rows; chevron-down icon on the right collapsed, chevron-up when expanded
+- Body answer renders inside the same row container in `{typography.body-md}` after expansion
+
+**`help-band-dark`** — the closing "How can we help?" prelude band
+- Background `{colors.ink}`, text `{colors.on-primary}`, padding 64px {spacing.xl}
+- Layout: large lifestyle photograph as the band background (low-opacity) with chip-style category tabs centered: Browse Topics / Live Chat / Contact / Diagnose / Order Status
+
+**`footer-dark`**
+- Background `{colors.ink}`, text `{colors.on-primary}`, type `{typography.body-md}`, padding 64px {spacing.xl}
+- 5-column link grid (Company / Shop / Support / Resources / Connect) with `{typography.body-emphasis}` headers and `{typography.caption-md}` link rows
+- Bottom strip carries social icons, language picker, and legal lines in `{typography.caption-sm}` muted to `{colors.steel}`
+
+## Do's and Don'ts
+
+### Do
+- Reserve `{colors.primary}` for the primary CTA, link color, and `chevron-decoration` motif — at most twice per viewport
+- Set every headline in Forma DJR Micro at weight 500 with line-height 1.0 — resist the urge to bump weight at hero scale
+- Use `{rounded.xl}` (16px) for cards and photo frames; `{rounded.md}` (4px) for buttons and inputs — keep the two-tier split sharp
+- Pair white `{colors.canvas}` body bands with `{colors.cloud}` (`#f7f7f7`) alternating bands; let the gray do the breathing
+- Close every page rhythm with a dark-navy `{colors.ink}` slab — the "How can we help?" prelude + footer
+- Set button labels in uppercase with `{typography.button-md}` (0.7px tracking) — the only place the system tracks letters
+- Use Soft Lift shadow exclusively for product cards and pricing tiers — leave section bands flat
+- Frame product photography inside `{rounded.xl}` containers; never use full-bleed circular masks
+
+### Don't
+- Don't introduce secondary saturated colors outside `{colors.primary}` family + the `bloom-coral` sale-tag and `storm` printer-plan accents
+- Don't apply heavy material shadows — depth is via color contrast (cloud vs. white) and Soft Lift only
+- Don't round buttons above `{rounded.md}` (4px); a soft 8px+ button reads as a different brand
+- Don't run Forma DJR Micro below 12px — small caption at 11px is the floor
+- Don't use the chevron decoration as inline noise; it is a hero-only architectural element tied to the wordmark
+- Don't drop ink text opacity to create hierarchy — switch surface or shift to `{colors.charcoal}` / `{colors.graphite}` instead
+- Don't replace the HP wordmark with a generic sans lockup; the wordmark is a custom mark with its own ratio
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 480px | Single-column stack; hamburger nav; section padding drops to ~48px; hero serif scales to ~36px |
+| Mobile-Large | 480–767px | Same column count; hero scales to ~44px; pricing tiers stack vertically |
+| Tablet | 768–1023px | 2-column product grid; pricing 2x2; nav still full text labels |
+| Desktop | 1024–1279px | 3-column product grid; 4-column pricing; full nav |
+| Desktop-Large | ≥ 1280px | 4-column product grid; 1366px content max-width with full-bleed bands |
+
+### Touch Targets
+
+Every interactive element clears 44×44px on mobile. `button-primary` at 44px height + 24px horizontal padding meets WCAG-AAA touch target. `category-tab` at 8px 20px padding bumps to 12px 24px on touch screens. Nav-link tap areas extend invisibly beyond the text run to the full 44px row height. Sticky cart/sign-in icons in the top nav use 44×44 invisible hit boxes around their visible 24×24 glyph.
+
+### Collapsing Strategy
+
+- **Utility strip**: stays visible on every breakpoint; dropdowns collapse into a single "Account" icon below 768px
+- **Top nav**: middle category list collapses into a hamburger drawer below 1024px; the right-side Search + Sign-in + Cart stay visible
+- **Hero**: stays single-column at every breakpoint; chevron decorations shrink to ~60% size on tablet and disappear entirely on mobile
+- **Product family grid**: 4 → 3 → 2 → 1 column as breakpoints shrink; cards keep `{rounded.xl}` corners at every size
+- **Pricing comparison table**: 4-column grid on desktop collapses to 2x2 on tablet, then stacks into individual accordion-style cards on mobile
+- **Footer**: 5-column link grid → 2-column tablet → single-column accordion on mobile; HP wordmark stays flush left
+
+### Image Behavior
+
+Hero photography uses `{rounded.xl}` containers at every breakpoint. The chevron decorations vanish on mobile; the underlying photo card centers in the viewport. Lifestyle photography in the testimonial and "how-can-we-help" bands maintains 16:9 ratio with horizontal cropping rather than letterboxing on mobile. There are no art-direction crop swaps between desktop and mobile — the same image is used at every size.
+
+## Iteration Guide
+
+1. Focus on ONE component at a time; resist refactoring an entire section in one pass
+2. Reference component names and tokens directly (`{colors.primary}`, `{typography.display-xxl}`, `{rounded.xl}`, `card-product`) — do not paraphrase to hex/px in prose
+3. Run `npx @google/design.md lint DESIGN.md` after edits — `broken-ref`, `contrast-ratio`, and `orphaned-tokens` warnings flag issues automatically
+4. Add new variants as separate component entries (`-pressed`, `-disabled`, `-focused`); never bury state inside prose
+5. Default body to `{typography.body-md}`; reach for `{typography.body-emphasis}` for run-in bolds; keep display sizes for true heading roles
+6. Keep `{colors.primary}` scarce — at most two flame elements per viewport (one CTA + one chevron decoration). Three flame items in one viewport is over-saturation
+7. When introducing a new section band, choose from `{colors.canvas}` / `{colors.cloud}` / `{colors.fog}` / `{colors.ink}` — six pre-defined surface modes is the entire surface vocabulary

--- a/README.md
+++ b/README.md
@@ -43,13 +43,18 @@ The quick run shows a blue/white result card in the terminal. It does not write 
 
 ## Cloud Setup
 
-For shared/public usage, point the CLI at your Skillcheck Cloud endpoint:
+The hosted option lets users run checks without any model-provider key of their own. Deploy the **`dashboard/`** folder on Vercel: users sign in with GitHub, get a Skillcheck API key with 10 free runs, and the CLI proxies through your server-side NVIDIA key (after the free runs they upgrade via Stripe). Full click-by-click walkthrough in **`dashboard/SETUP.md`**.
+
+Once deployed, the CLI connects with:
 
 ```bash
-export SKILLCHECK_API_URL=https://api.yourdomain.com/v1
+export SKILLCHECK_API_URL=https://your-app.vercel.app/api
+export SKILLCHECK_TOKEN=sk_live_...   # from your dashboard
 ```
 
-See `docs/skillcheck-cloud.md` for the proxy and dashboard plan.
+Or run `skillcheck setup` and paste the URL and key when prompted.
+
+Other references: `dashboard.md` is a drop-in single-file connect page for users who run their own proxy; `docs/skillcheck-cloud.md` documents the OpenAI-compatible API contract and a minimal proxy; `docs/skillcheck-cloud-build-plan.md` is the deeper multi-service architecture.
 
 ## Local Development
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -51,6 +51,7 @@ npm run site:build
 npm audit
 npm pack --dry-run
 npx --yes github-actionlint .github/workflows/rot.yml
+( cd dashboard && npm test )
 ```
 
 Confirm no skipped tests:
@@ -60,6 +61,29 @@ rg "\\.skip|describe\\.skip|it\\.skip|test\\.skip|skip\\(" packages/cli/test pac
 ```
 
 The command above should print nothing.
+
+## Dashboard (Skillcheck Cloud)
+
+1. Run the dashboard logic + proxy integration tests:
+
+   ```bash
+   ( cd dashboard && npm test )
+   ```
+
+2. Deploy `dashboard/` on Vercel and configure every variable per `dashboard/SETUP.md` (Root Directory = `dashboard`, Framework = Other).
+3. Smoke-test the live flow: sign in with GitHub → a `sk_live_…` key appears → `skillcheck check` against `SKILLCHECK_API_URL=https://<app>/api` increments dashboard usage by one.
+4. Confirm free-run gating: the 11th run returns HTTP 402 with the upgrade link.
+
+## Public Repository Readiness
+
+Before flipping the repo to public, confirm no secrets are committed:
+
+```bash
+git ls-files | xargs rg -n "nvapi-[A-Za-z0-9_-]{8,}|sk_live_[A-Za-z0-9]{16,}|UPSTASH_REDIS_REST_TOKEN=.+|AUTH_GITHUB_SECRET=.+|STRIPE_SECRET_KEY=sk_[A-Za-z0-9]{16,}" || echo "clean"
+git check-ignore .env dashboard/.env
+```
+
+The first command should print `clean`; the second should echo both paths (they are git-ignored). Also confirm `dashboard/.env.example` ships only empty placeholders.
 
 ## Publish Steps
 

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,0 +1,42 @@
+# Skillcheck dashboard — environment variables.
+# Set these in the Vercel project (Settings → Environment Variables), not in code.
+# See SETUP.md for where each value comes from.
+
+# --- Upstream model provider (REQUIRED) ---
+# Your single NVIDIA NIM key. Stays on the server; never shipped to the CLI/browser.
+NVIDIA_API_KEY=
+NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
+# The hosted tier pins this model for all requests (cost control).
+SKILLCHECK_MODEL=qwen/qwen3-next-80b-a3b-instruct
+
+# --- Auth: GitHub OAuth (REQUIRED) ---
+# Create at https://github.com/settings/developers → New OAuth App.
+# Authorization callback URL must be: https://YOUR-APP.vercel.app/api/auth/callback
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=
+# Random 32+ byte secret for signing session cookies. Generate: openssl rand -base64 32
+AUTH_SECRET=
+# Extra pepper for hashing API keys before storage (defaults to AUTH_SECRET if unset).
+TOKEN_PEPPER=
+
+# --- Storage: Upstash Redis (REQUIRED in production) ---
+# Create a database at https://console.upstash.com → copy the REST URL + token.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# --- Quota ---
+# Free runs included per account before payment is required.
+FREE_RUNS=10
+# Run cap for paid users. 0 = unlimited.
+PRO_RUN_LIMIT=0
+
+# --- Billing: Stripe (OPTIONAL; upgrade button hides when unset) ---
+# https://dashboard.stripe.com/apikeys  and a Price at https://dashboard.stripe.com/products
+STRIPE_SECRET_KEY=
+STRIPE_PRICE_ID=
+# 'payment' for a one-time unlock, or 'subscription' for recurring.
+STRIPE_MODE=payment
+
+# --- Optional ---
+# Force the public URL (otherwise derived from request headers). No trailing slash.
+# APP_URL=https://YOUR-APP.vercel.app

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,38 @@
+# Skillcheck Dashboard
+
+The hosted Skillcheck Cloud app: users sign in with GitHub, get a Skillcheck API key with **10 free runs**, and the CLI proxies through here to your server-side NVIDIA key. After the free runs, they upgrade via Stripe.
+
+Zero-dependency, zero-build — static HTML/CSS/JS plus Vercel serverless functions. **Deploy this folder on Vercel.**
+
+```
+dashboard/
+  index.html            Landing page (sign in, pricing)        — HP-style design (see ../DESIGN.md)
+  app.html              Signed-in dashboard (key, usage, preview)
+  assets/               styles.css, app.js, landing.js
+  api/
+    health.js           GET  /api/health
+    me.js               GET  /api/me              (session → account)
+    auth/login,callback,logout.js                 GitHub OAuth
+    key/rotate.js       POST /api/key/rotate
+    chat/completions.js POST /api/chat/completions (the metered proxy the CLI hits)
+    billing/checkout,confirm.js                   Stripe upgrade
+    _lib/               config, store (Upstash), session, keys, users, nvidia, stripe
+  test/                 smoke.mjs + proxy.mjs (run with `npm test`)
+  .env.example          every variable, documented
+  SETUP.md              full click-by-click deploy + API-key guide
+```
+
+## Quick start
+
+1. Read **[SETUP.md](SETUP.md)** — it walks through NVIDIA, Upstash, GitHub OAuth, Stripe, and the Vercel deploy.
+2. Deploy on Vercel with **Root Directory = `dashboard`** and **Framework = Other**.
+3. The CLI connects with `SKILLCHECK_API_URL=https://your-app.vercel.app/api` and `SKILLCHECK_TOKEN=sk_live_…`.
+
+## How metering works
+
+A "run" is one `skillcheck check`. The CLI tags every model call in a run with the same `x-skillcheck-run` id; the proxy counts **distinct** ids, so one check = one run regardless of how many model calls it makes. Free accounts get `FREE_RUNS` (default 10); the first call of the 11th run returns HTTP 402 with an upgrade link.
+
+```bash
+cd dashboard
+npm test          # logic + proxy integration smoke tests (offline)
+```

--- a/dashboard/SETUP.md
+++ b/dashboard/SETUP.md
@@ -1,0 +1,186 @@
+# Skillcheck Dashboard — Setup Guide
+
+This is the complete, click-by-click guide to deploy the dashboard and wire up every API key. Follow it top to bottom once. Total time: ~20–30 minutes.
+
+## What you are building
+
+```
+User → signs in with GitHub on your dashboard
+     → gets a Skillcheck API key (sk_live_…) with 10 free runs
+     → pastes it into the skillcheck CLI
+CLI  → calls https://your-app.vercel.app/api/chat/completions  (Bearer sk_live_…)
+Proxy→ authenticates the key, meters the run, then calls NVIDIA with YOUR server key
+     → after 10 runs, returns 402 and the user upgrades (Stripe)
+```
+
+Your NVIDIA key lives **only** on Vercel as an environment variable. It is never in the npm package, the browser, or the user's terminal.
+
+## What you need (5 accounts, all have free tiers)
+
+| Platform | Used for | Required |
+|---|---|---|
+| [Vercel](https://vercel.com) | Hosts the dashboard + API | Yes |
+| [NVIDIA build](https://build.nvidia.com) | The model provider (NIM) | Yes |
+| [Upstash](https://upstash.com) | Redis database (users, keys, run counts) | Yes |
+| [GitHub OAuth](https://github.com/settings/developers) | Sign-in | Yes |
+| [Stripe](https://stripe.com) | Paid upgrade after 10 runs | Optional |
+
+---
+
+## Step 1 — NVIDIA API key (the upstream model)
+
+1. Go to <https://build.nvidia.com>, sign in.
+2. Open any model (e.g. **qwen/qwen3-next-80b-a3b-instruct**).
+3. Click **Get API Key** / **Generate Key**. It looks like `nvapi-…`.
+4. Save it. You will paste it as `NVIDIA_API_KEY` in Step 5.
+
+> The dashboard pins all hosted requests to `SKILLCHECK_MODEL` (default `qwen/qwen3-next-80b-a3b-instruct`) for cost control. Change it in env if you want a different backing model.
+
+## Step 2 — Upstash Redis (storage)
+
+1. Go to <https://console.upstash.com>, sign in.
+2. **Create Database** → name `skillcheck` → pick a region near your Vercel region → **Create**.
+3. On the database page, scroll to **REST API** and copy:
+   - **UPSTASH_REDIS_REST_URL** (e.g. `https://us1-xxx.upstash.io`)
+   - **UPSTASH_REDIS_REST_TOKEN** (a long token)
+4. Save both for Step 5.
+
+> Without Upstash the app falls back to in-memory storage, which is wiped on every deploy/instance — fine for local testing, not for production.
+
+## Step 3 — GitHub OAuth app (sign-in)
+
+You need your final app URL for the callback. If you do not have it yet, do Step 5 first to get the `https://<app>.vercel.app` URL, then come back.
+
+1. Go to <https://github.com/settings/developers> → **OAuth Apps** → **New OAuth App**.
+2. Fill in:
+   - **Application name**: `Skillcheck`
+   - **Homepage URL**: `https://YOUR-APP.vercel.app`
+   - **Authorization callback URL**: `https://YOUR-APP.vercel.app/api/auth/callback`
+3. **Register application**.
+4. Copy the **Client ID** → `AUTH_GITHUB_ID`.
+5. Click **Generate a new client secret** → copy it → `AUTH_GITHUB_SECRET`.
+
+## Step 4 — Generate auth secrets
+
+Run locally and copy each output:
+
+```bash
+openssl rand -base64 32   # → AUTH_SECRET
+openssl rand -base64 32   # → TOKEN_PEPPER
+```
+
+`AUTH_SECRET` signs login cookies. `TOKEN_PEPPER` hashes API keys before storage.
+
+## Step 5 — Deploy to Vercel
+
+1. Push this repository to GitHub (the dashboard lives in the `dashboard/` folder).
+2. Go to <https://vercel.com/new> → **Import** your repo.
+3. **Configure Project**:
+   - **Root Directory**: click **Edit** → select `dashboard`.
+   - **Framework Preset**: **Other** (it is plain static files + serverless functions — no build step).
+4. Expand **Environment Variables** and add everything from the table below.
+5. **Deploy**. You get a URL like `https://skillcheck-xyz.vercel.app`.
+6. If you had not created the GitHub OAuth app yet, do Step 3 now with this URL, then add `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET` in **Settings → Environment Variables** and **redeploy**.
+
+### Environment variables to set in Vercel
+
+| Name | Value / source | Required |
+|---|---|---|
+| `NVIDIA_API_KEY` | `nvapi-…` from Step 1 | Yes |
+| `NVIDIA_BASE_URL` | `https://integrate.api.nvidia.com/v1` | No (default) |
+| `SKILLCHECK_MODEL` | `qwen/qwen3-next-80b-a3b-instruct` | No (default) |
+| `UPSTASH_REDIS_REST_URL` | from Step 2 | Yes |
+| `UPSTASH_REDIS_REST_TOKEN` | from Step 2 | Yes |
+| `AUTH_GITHUB_ID` | from Step 3 | Yes |
+| `AUTH_GITHUB_SECRET` | from Step 3 | Yes |
+| `AUTH_SECRET` | from Step 4 | Yes |
+| `TOKEN_PEPPER` | from Step 4 | Recommended |
+| `FREE_RUNS` | `10` | No (default) |
+| `PRO_RUN_LIMIT` | `0` (0 = unlimited) | No |
+| `STRIPE_SECRET_KEY` | from Step 7 | Only for billing |
+| `STRIPE_PRICE_ID` | from Step 7 | Only for billing |
+| `STRIPE_MODE` | `payment` or `subscription` | No (default `payment`) |
+
+> After changing any env var, **redeploy** — Vercel applies env vars to new deployments only.
+
+## Step 6 — Test the core flow (do this before billing)
+
+1. Visit `https://YOUR-APP.vercel.app` → **Sign in with GitHub** → authorize.
+2. You land on the dashboard with a `sk_live_…` key, usage `0 / 10`, and quickstart commands.
+3. In a terminal:
+
+   ```bash
+   npm install -g @sx4im/skillcheck
+   export SKILLCHECK_API_URL=https://YOUR-APP.vercel.app/api
+   export SKILLCHECK_TOKEN=sk_live_...        # your key from the dashboard
+   skillcheck check ./SKILL.md
+   ```
+
+4. Reload the dashboard — **Usage** should tick up by 1. That confirms: auth → key → metered proxy → NVIDIA all work.
+
+## Step 7 — Stripe upgrade (optional)
+
+Skip this to launch a free-only beta; the Upgrade button stays hidden until both Stripe vars are set.
+
+1. Go to <https://dashboard.stripe.com/apikeys> → copy the **Secret key** (`sk_live_…` or `sk_test_…`) → `STRIPE_SECRET_KEY`.
+2. Go to <https://dashboard.stripe.com/products> → **Add product** → set a price (e.g. $19 one-time) → copy the **Price ID** (`price_…`) → `STRIPE_PRICE_ID`.
+3. Set `STRIPE_MODE=payment` (one-time unlock) or `subscription` (recurring).
+4. Add the three vars in Vercel → **redeploy**.
+5. The dashboard now shows **Upgrade to Pro**. Payment redirects to Stripe Checkout and, on return, the app verifies the session server-side and flips the account to `pro` (unlimited). No webhook required.
+
+> Use Stripe **test mode** keys + card `4242 4242 4242 4242` to rehearse before going live.
+
+---
+
+## Connecting the CLI (what your users do)
+
+Give users either flow:
+
+```bash
+# Interactive
+skillcheck setup     # paste the API URL, then the API key
+
+# Or environment variables
+export SKILLCHECK_API_URL=https://YOUR-APP.vercel.app/api
+export SKILLCHECK_TOKEN=sk_live_...
+skillcheck check ./SKILL.md
+```
+
+When free runs run out, the CLI prints a clear message with your dashboard URL to upgrade.
+
+## Operating it
+
+- **Change free-run allowance**: set `FREE_RUNS` and redeploy.
+- **Give someone Pro manually**: in the Upstash console, find `user:<uid>`, set `"plan":"pro"`. (Find the uid via `ghid:<githubId>`.)
+- **A user lost / leaked their key**: they click **Rotate key** in the dashboard; the old key stops working immediately.
+- **Cost control**: every hosted request is pinned to one model and capped at `max_tokens` by the CLI; metering caps free usage at `FREE_RUNS` runs per account.
+
+## Security notes
+
+- `NVIDIA_API_KEY`, `STRIPE_SECRET_KEY`, `UPSTASH_*`, `AUTH_SECRET` live only in Vercel env vars — never commit them.
+- API keys are stored so the dashboard can show them to their owner; they are also indexed by `sha256(key + TOKEN_PEPPER)` for proxy lookup. They grant only metered access to your proxy and are revocable by rotation.
+- Session cookies are HttpOnly, Secure, SameSite=Lax, and HMAC-signed with `AUTH_SECRET`.
+- The proxy uses Bearer-key auth (not cookies), so its permissive CORS cannot be abused with a victim's ambient credentials.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `GitHub sign-in is not configured` | `AUTH_GITHUB_ID` not set, or you didn't redeploy after setting it |
+| Redirect loop / `error=oauth_state` | The OAuth **callback URL** must be exactly `https://YOUR-APP.vercel.app/api/auth/callback` |
+| Dashboard shows the key but the CLI says "not connected" | `SKILLCHECK_API_URL` must end in `/api` (e.g. `https://app.vercel.app/api`) |
+| `Server is missing NVIDIA_API_KEY` from a check | Set `NVIDIA_API_KEY` in Vercel and redeploy |
+| Usage never increments | `UPSTASH_*` not set → in-memory store resets per request; add Upstash |
+| Upgrade button missing | Set both `STRIPE_SECRET_KEY` and `STRIPE_PRICE_ID`, then redeploy |
+| Checks fail with a timeout | The proxy is configured for a 60s `maxDuration` (`vercel.json`). Vercel's Hobby plan may cap function duration lower — upgrade the Vercel plan if long model calls are cut off |
+
+## Local development
+
+```bash
+cd dashboard
+npm install -g vercel        # once
+vercel dev                   # serves static pages + /api functions on localhost
+npm test                     # runs the logic + proxy integration smoke tests
+```
+
+For `vercel dev`, put the same variables in a local `.env` (copy from `.env.example`). Without Upstash it uses an in-memory store that resets when the dev server restarts.

--- a/dashboard/api/_lib/config.js
+++ b/dashboard/api/_lib/config.js
@@ -1,0 +1,46 @@
+// Central environment configuration for the Skillcheck dashboard + proxy.
+// Every secret is read here so the rest of the code never touches process.env directly.
+
+function clean(value) {
+  return (value || '').trim();
+}
+
+// --- Upstream model provider (the ONE secret that must never reach the browser/CLI) ---
+export const NVIDIA_API_KEY = clean(process.env.NVIDIA_API_KEY);
+export const NVIDIA_BASE_URL = (clean(process.env.NVIDIA_BASE_URL) || 'https://integrate.api.nvidia.com/v1').replace(/\/+$/, '');
+export const DEFAULT_MODEL =
+  clean(process.env.SKILLCHECK_MODEL) || clean(process.env.DEFAULT_MODEL) || 'qwen/qwen3-next-80b-a3b-instruct';
+
+// --- Auth (GitHub OAuth + signed session cookie) ---
+export const AUTH_SECRET = clean(process.env.AUTH_SECRET);
+export const GITHUB_ID = clean(process.env.AUTH_GITHUB_ID) || clean(process.env.GITHUB_CLIENT_ID);
+export const GITHUB_SECRET = clean(process.env.AUTH_GITHUB_SECRET) || clean(process.env.GITHUB_CLIENT_SECRET);
+
+// Pepper used when hashing issued API keys before storing them.
+export const TOKEN_PEPPER = clean(process.env.TOKEN_PEPPER) || AUTH_SECRET || 'skillcheck-dev-pepper';
+
+// --- Quota ---
+export const FREE_RUNS = Number(process.env.FREE_RUNS || 10);
+// 0 = unlimited for paid users.
+export const PRO_RUN_LIMIT = Number(process.env.PRO_RUN_LIMIT || 0);
+
+// --- Billing (optional; upgrade is hidden when STRIPE_SECRET_KEY is unset) ---
+export const STRIPE_SECRET_KEY = clean(process.env.STRIPE_SECRET_KEY);
+export const STRIPE_PRICE_ID = clean(process.env.STRIPE_PRICE_ID);
+export const STRIPE_MODE = clean(process.env.STRIPE_MODE) || 'payment'; // 'payment' (one-time) or 'subscription'
+
+// --- Storage ---
+export const UPSTASH_URL = clean(process.env.UPSTASH_REDIS_REST_URL);
+export const UPSTASH_TOKEN = clean(process.env.UPSTASH_REDIS_REST_TOKEN);
+
+// Optional explicit public app URL (otherwise derived from request headers).
+export const APP_URL = clean(process.env.APP_URL).replace(/\/+$/, '');
+
+export const billingEnabled = Boolean(STRIPE_SECRET_KEY && STRIPE_PRICE_ID);
+
+export function appUrl(req) {
+  if (APP_URL) return APP_URL;
+  const proto = String(req.headers['x-forwarded-proto'] || 'https').split(',')[0];
+  const host = req.headers['x-forwarded-host'] || req.headers.host || 'localhost:3000';
+  return `${proto}://${host}`;
+}

--- a/dashboard/api/_lib/http.js
+++ b/dashboard/api/_lib/http.js
@@ -1,0 +1,76 @@
+// Small helpers shared by every serverless function.
+
+export function sendJson(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(body));
+}
+
+export function methodNotAllowed(res, allow) {
+  res.setHeader('allow', allow);
+  sendJson(res, 405, { error: { message: `Method not allowed. Use ${allow}.` } });
+}
+
+// Permissive CORS for the proxy endpoint only. Safe because auth is by Bearer
+// API key, not by cookie, so '*' cannot be abused with ambient credentials.
+export function proxyCors(res) {
+  res.setHeader('access-control-allow-origin', '*');
+  res.setHeader('access-control-allow-headers', 'authorization, content-type, x-skillcheck-run');
+  res.setHeader('access-control-allow-methods', 'POST, GET, OPTIONS');
+}
+
+export function bearerToken(req) {
+  const header = req.headers['authorization'] || '';
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1].trim() : '';
+}
+
+export function redirect(res, location) {
+  res.statusCode = 302;
+  res.setHeader('location', location);
+  res.end();
+}
+
+// Vercel parses JSON bodies into req.body; locally (node http) it may be a stream.
+export async function readJsonBody(req) {
+  if (req.body && typeof req.body === 'object') return req.body;
+  if (typeof req.body === 'string') {
+    try { return JSON.parse(req.body); } catch { return {}; }
+  }
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  if (chunks.length === 0) return {};
+  try { return JSON.parse(Buffer.concat(chunks).toString('utf8')); } catch { return {}; }
+}
+
+export function parseCookies(req) {
+  const out = {};
+  const raw = req.headers['cookie'];
+  if (!raw) return out;
+  for (const part of raw.split(';')) {
+    const index = part.indexOf('=');
+    if (index === -1) continue;
+    out[part.slice(0, index).trim()] = decodeURIComponent(part.slice(index + 1).trim());
+  }
+  return out;
+}
+
+export function setCookie(res, name, value, options = {}) {
+  const segments = [`${name}=${encodeURIComponent(value)}`];
+  segments.push(`Path=${options.path || '/'}`);
+  if (options.maxAge != null) segments.push(`Max-Age=${options.maxAge}`);
+  segments.push(`SameSite=${options.sameSite || 'Lax'}`);
+  if (options.httpOnly !== false) segments.push('HttpOnly');
+  if (options.secure !== false) segments.push('Secure');
+  appendHeader(res, 'Set-Cookie', segments.join('; '));
+}
+
+export function clearCookie(res, name) {
+  appendHeader(res, 'Set-Cookie', `${name}=; Path=/; Max-Age=0; SameSite=Lax; HttpOnly; Secure`);
+}
+
+function appendHeader(res, name, value) {
+  const existing = res.getHeader(name);
+  if (!existing) res.setHeader(name, value);
+  else res.setHeader(name, Array.isArray(existing) ? [...existing, value] : [existing, value]);
+}

--- a/dashboard/api/_lib/keys.js
+++ b/dashboard/api/_lib/keys.js
@@ -1,0 +1,20 @@
+// Skillcheck API key helpers. Keys look like `sk_live_<random>` and are what the
+// user pastes into the CLI as SKILLCHECK_TOKEN. The proxy authenticates a request
+// by hashing the presented key and looking the hash up in the store.
+
+import { createHash, randomBytes } from 'node:crypto';
+import { TOKEN_PEPPER } from './config.js';
+
+export function generateApiKey(live = true) {
+  const random = randomBytes(24).toString('base64url');
+  return `sk_${live ? 'live' : 'test'}_${random}`;
+}
+
+export function hashApiKey(key) {
+  return createHash('sha256').update(`${key}.${TOKEN_PEPPER}`).digest('hex');
+}
+
+export function maskApiKey(key) {
+  if (!key || key.length < 16) return key || '';
+  return `${key.slice(0, 11)}…${key.slice(-4)}`;
+}

--- a/dashboard/api/_lib/nvidia.js
+++ b/dashboard/api/_lib/nvidia.js
@@ -1,0 +1,22 @@
+// Forwards an OpenAI-compatible chat-completion to the upstream provider using
+// the server-side NVIDIA key. The hosted tier pins the model for cost control.
+
+import { NVIDIA_API_KEY, NVIDIA_BASE_URL, DEFAULT_MODEL } from './config.js';
+
+export async function forwardChatCompletion(body) {
+  const payload = { ...body, model: DEFAULT_MODEL, stream: false };
+  const upstream = await fetch(`${NVIDIA_BASE_URL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${NVIDIA_API_KEY}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+  const text = await upstream.text();
+  return {
+    status: upstream.status,
+    contentType: upstream.headers.get('content-type') || 'application/json',
+    text
+  };
+}

--- a/dashboard/api/_lib/session.js
+++ b/dashboard/api/_lib/session.js
@@ -1,0 +1,54 @@
+// Stateless signed-cookie session. The cookie value is `<payload>.<hmac>` where
+// payload is base64url(JSON) and hmac is HMAC-SHA256(payload, AUTH_SECRET). No
+// server-side session store is needed; tampering invalidates the signature.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { AUTH_SECRET } from './config.js';
+import { parseCookies, setCookie, clearCookie } from './http.js';
+
+const COOKIE = 'sc_session';
+const MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+function secret() {
+  // Falls back to a dev secret so local runs work; production MUST set AUTH_SECRET.
+  return AUTH_SECRET || 'skillcheck-dev-auth-secret-change-me';
+}
+
+function sign(payloadB64) {
+  return createHmac('sha256', secret()).update(payloadB64).digest('base64url');
+}
+
+export function createSessionToken(data) {
+  const payload = Buffer.from(JSON.stringify({ ...data, iat: Date.now() })).toString('base64url');
+  return `${payload}.${sign(payload)}`;
+}
+
+export function verifySessionToken(token) {
+  if (!token || typeof token !== 'string') return null;
+  const dot = token.lastIndexOf('.');
+  if (dot === -1) return null;
+  const payload = token.slice(0, dot);
+  const provided = token.slice(dot + 1);
+  const expected = sign(payload);
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  try {
+    return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function getSession(req) {
+  const token = parseCookies(req)[COOKIE];
+  return verifySessionToken(token);
+}
+
+export function setSession(res, data) {
+  setCookie(res, COOKIE, createSessionToken(data), { maxAge: MAX_AGE, httpOnly: true, sameSite: 'Lax', secure: true });
+}
+
+export function clearSession(res) {
+  clearCookie(res, COOKIE);
+}

--- a/dashboard/api/_lib/store.js
+++ b/dashboard/api/_lib/store.js
@@ -1,0 +1,67 @@
+// Key/value store. Uses Upstash Redis over its REST API in production, and an
+// in-process Map for local dev / tests when Upstash is not configured.
+//
+// NOTE: the in-memory fallback only persists within a single warm process, so it
+// is fine for `vercel dev` and unit tests but NOT for real multi-instance prod.
+// Set UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN for production.
+
+import { UPSTASH_URL, UPSTASH_TOKEN } from './config.js';
+
+export const usingRedis = Boolean(UPSTASH_URL && UPSTASH_TOKEN);
+
+const mem = globalThis.__skillcheckMem || (globalThis.__skillcheckMem = { kv: new Map(), exp: new Map() });
+
+async function upstash(command) {
+  const response = await fetch(UPSTASH_URL, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${UPSTASH_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify(command)
+  });
+  const data = await response.json();
+  if (data && data.error) throw new Error(`store error: ${data.error}`);
+  return data ? data.result : null;
+}
+
+function memLive(key) {
+  const expiry = mem.exp.get(key);
+  if (expiry !== undefined && expiry < Date.now()) {
+    mem.kv.delete(key);
+    mem.exp.delete(key);
+    return false;
+  }
+  return mem.kv.has(key);
+}
+
+export async function kvGet(key) {
+  if (usingRedis) return upstash(['GET', key]);
+  return memLive(key) ? mem.kv.get(key) : null;
+}
+
+// options: { ex?: seconds, nx?: boolean }. Returns 'OK' on write, null when nx skipped.
+export async function kvSet(key, value, options = {}) {
+  if (usingRedis) {
+    const command = ['SET', key, value];
+    if (options.ex) command.push('EX', String(options.ex));
+    if (options.nx) command.push('NX');
+    return upstash(command);
+  }
+  if (options.nx && memLive(key)) return null;
+  mem.kv.set(key, value);
+  if (options.ex) mem.exp.set(key, Date.now() + options.ex * 1000);
+  else mem.exp.delete(key);
+  return 'OK';
+}
+
+export async function kvDel(key) {
+  if (usingRedis) return upstash(['DEL', key]);
+  mem.kv.delete(key);
+  mem.exp.delete(key);
+  return 1;
+}
+
+export async function kvIncr(key) {
+  if (usingRedis) return upstash(['INCR', key]);
+  const next = Number(memLive(key) ? mem.kv.get(key) : 0) + 1;
+  mem.kv.set(key, String(next));
+  return next;
+}

--- a/dashboard/api/_lib/stripe.js
+++ b/dashboard/api/_lib/stripe.js
@@ -1,0 +1,42 @@
+// Minimal Stripe REST client (no SDK dependency). Used for the upgrade flow:
+// create a Checkout Session, then verify it server-side on return.
+
+import { STRIPE_SECRET_KEY, STRIPE_PRICE_ID, STRIPE_MODE } from './config.js';
+
+function formEncode(params) {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) search.append(key, String(value));
+  }
+  return search.toString();
+}
+
+async function stripe(path, method, params) {
+  const response = await fetch(`https://api.stripe.com/v1/${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    body: params ? formEncode(params) : undefined
+  });
+  const data = await response.json();
+  if (data && data.error) throw new Error(data.error.message || 'Stripe error');
+  return data;
+}
+
+export async function createCheckoutSession({ uid, email, successUrl, cancelUrl }) {
+  return stripe('checkout/sessions', 'POST', {
+    mode: STRIPE_MODE,
+    'line_items[0][price]': STRIPE_PRICE_ID,
+    'line_items[0][quantity]': 1,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    client_reference_id: uid,
+    ...(email ? { customer_email: email } : {})
+  });
+}
+
+export async function getCheckoutSession(id) {
+  return stripe(`checkout/sessions/${encodeURIComponent(id)}`, 'GET');
+}

--- a/dashboard/api/_lib/users.js
+++ b/dashboard/api/_lib/users.js
@@ -1,0 +1,105 @@
+// User records + run metering.
+//
+// Store layout:
+//   user:<uid>          JSON { uid, ghId, email, name, plan, apiKey, createdAt }
+//   ghid:<ghId>         -> uid                  (find a returning GitHub user)
+//   key:<sha256(key)>   -> uid                  (proxy authenticates by this)
+//   runsused:<uid>      integer                 (atomic INCR per consumed run)
+//   run:<uid>:<runId>   short-lived marker      (dedupes the many calls in one run)
+
+import { randomUUID } from 'node:crypto';
+import { kvGet, kvSet, kvDel, kvIncr } from './store.js';
+import { generateApiKey, hashApiKey } from './keys.js';
+import { FREE_RUNS, PRO_RUN_LIMIT } from './config.js';
+
+export async function getUser(uid) {
+  const raw = await kvGet(`user:${uid}`);
+  return raw ? JSON.parse(raw) : null;
+}
+
+async function saveUser(user) {
+  await kvSet(`user:${user.uid}`, JSON.stringify(user));
+  return user;
+}
+
+export async function getRunsUsed(uid) {
+  return Number((await kvGet(`runsused:${uid}`)) || 0);
+}
+
+export async function uidForApiKey(key) {
+  if (!key) return null;
+  return kvGet(`key:${hashApiKey(key)}`);
+}
+
+export async function createOrGetUserFromGithub({ ghId, email, name }) {
+  const existingUid = await kvGet(`ghid:${ghId}`);
+  if (existingUid) {
+    const existing = await getUser(existingUid);
+    if (existing) return existing;
+  }
+  const uid = randomUUID();
+  const apiKey = generateApiKey();
+  const user = {
+    uid,
+    ghId: String(ghId),
+    email: email || '',
+    name: name || '',
+    plan: 'free',
+    apiKey,
+    createdAt: new Date().toISOString()
+  };
+  await saveUser(user);
+  await kvSet(`ghid:${ghId}`, uid);
+  await kvSet(`key:${hashApiKey(apiKey)}`, uid);
+  return user;
+}
+
+export async function rotateApiKey(uid) {
+  const user = await getUser(uid);
+  if (!user) return null;
+  if (user.apiKey) await kvDel(`key:${hashApiKey(user.apiKey)}`);
+  const apiKey = generateApiKey();
+  user.apiKey = apiKey;
+  await saveUser(user);
+  await kvSet(`key:${hashApiKey(apiKey)}`, uid);
+  return user;
+}
+
+export async function setPlan(uid, plan) {
+  const user = await getUser(uid);
+  if (!user) return null;
+  user.plan = plan;
+  return saveUser(user);
+}
+
+export function runLimitFor(plan) {
+  if (plan === 'pro') return PRO_RUN_LIMIT > 0 ? PRO_RUN_LIMIT : Infinity;
+  return FREE_RUNS;
+}
+
+// Meter one inbound request against the user's run quota.
+// A "run" is one `skillcheck check`, which fires many model calls sharing one
+// x-skillcheck-run id; only the first call of a new id consumes a slot.
+// Returns { allowed, counted, used, limit, reason? }.
+export async function consumeRun(uid, runId, plan) {
+  const limit = runLimitFor(plan);
+  const used = await getRunsUsed(uid);
+
+  if (!runId) {
+    // Unmetered request (e.g. the dashboard's in-browser preview): allow, no charge.
+    return { allowed: true, counted: false, used, limit };
+  }
+
+  const isNewRun = (await kvSet(`run:${uid}:${runId}`, '1', { nx: true, ex: 86400 })) === 'OK';
+  if (!isNewRun) {
+    return { allowed: true, counted: false, used, limit };
+  }
+
+  if (used >= limit) {
+    await kvDel(`run:${uid}:${runId}`); // reject without consuming the slot
+    return { allowed: false, counted: false, used, limit, reason: 'quota_exceeded' };
+  }
+
+  const nowUsed = await kvIncr(`runsused:${uid}`);
+  return { allowed: true, counted: true, used: nowUsed, limit };
+}

--- a/dashboard/api/auth/callback.js
+++ b/dashboard/api/auth/callback.js
@@ -1,0 +1,59 @@
+import { redirect, parseCookies, clearCookie } from '../_lib/http.js';
+import { GITHUB_ID, GITHUB_SECRET, appUrl } from '../_lib/config.js';
+import { setSession } from '../_lib/session.js';
+import { createOrGetUserFromGithub } from '../_lib/users.js';
+
+export default async function handler(req, res) {
+  try {
+    const base = appUrl(req);
+    const url = new URL(req.url, base);
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    const expectedState = parseCookies(req)['sc_oauth_state'];
+
+    if (!code || !state || !expectedState || state !== expectedState) {
+      return redirect(res, '/?error=oauth_state');
+    }
+    clearCookie(res, 'sc_oauth_state');
+
+    const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: { accept: 'application/json', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        client_id: GITHUB_ID,
+        client_secret: GITHUB_SECRET,
+        code,
+        redirect_uri: `${base}/api/auth/callback`
+      })
+    });
+    const tokenData = await tokenResponse.json();
+    const accessToken = tokenData.access_token;
+    if (!accessToken) return redirect(res, '/?error=oauth_token');
+
+    const ghHeaders = {
+      authorization: `Bearer ${accessToken}`,
+      accept: 'application/vnd.github+json',
+      'user-agent': 'skillcheck-dashboard'
+    };
+    const gh = await (await fetch('https://api.github.com/user', { headers: ghHeaders })).json();
+
+    let email = gh.email;
+    if (!email) {
+      const emailsResponse = await fetch('https://api.github.com/user/emails', { headers: ghHeaders });
+      if (emailsResponse.ok) {
+        const emails = await emailsResponse.json();
+        const primary = Array.isArray(emails)
+          ? emails.find((entry) => entry.primary && entry.verified) || emails.find((entry) => entry.verified)
+          : null;
+        email = primary ? primary.email : undefined;
+      }
+    }
+    email = email || `${gh.login}@users.noreply.github.com`;
+
+    const user = await createOrGetUserFromGithub({ ghId: gh.id, email, name: gh.name || gh.login });
+    setSession(res, { uid: user.uid });
+    redirect(res, '/app.html');
+  } catch {
+    redirect(res, '/?error=oauth');
+  }
+}

--- a/dashboard/api/auth/login.js
+++ b/dashboard/api/auth/login.js
@@ -1,0 +1,19 @@
+import { randomBytes } from 'node:crypto';
+import { redirect, setCookie, sendJson } from '../_lib/http.js';
+import { GITHUB_ID, appUrl } from '../_lib/config.js';
+
+export default function handler(req, res) {
+  if (!GITHUB_ID) {
+    return sendJson(res, 500, { error: { message: 'GitHub sign-in is not configured (set AUTH_GITHUB_ID).' } });
+  }
+  const state = randomBytes(16).toString('hex');
+  setCookie(res, 'sc_oauth_state', state, { maxAge: 600, httpOnly: true, sameSite: 'Lax', secure: true });
+
+  const authorize = new URL('https://github.com/login/oauth/authorize');
+  authorize.searchParams.set('client_id', GITHUB_ID);
+  authorize.searchParams.set('redirect_uri', `${appUrl(req)}/api/auth/callback`);
+  authorize.searchParams.set('scope', 'read:user user:email');
+  authorize.searchParams.set('state', state);
+  authorize.searchParams.set('allow_signup', 'true');
+  redirect(res, authorize.toString());
+}

--- a/dashboard/api/auth/logout.js
+++ b/dashboard/api/auth/logout.js
@@ -1,0 +1,7 @@
+import { redirect } from '../_lib/http.js';
+import { clearSession } from '../_lib/session.js';
+
+export default function handler(req, res) {
+  clearSession(res);
+  redirect(res, '/');
+}

--- a/dashboard/api/billing/checkout.js
+++ b/dashboard/api/billing/checkout.js
@@ -1,0 +1,29 @@
+import { sendJson, methodNotAllowed } from '../_lib/http.js';
+import { getSession } from '../_lib/session.js';
+import { getUser } from '../_lib/users.js';
+import { billingEnabled, appUrl } from '../_lib/config.js';
+import { createCheckoutSession } from '../_lib/stripe.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return methodNotAllowed(res, 'POST');
+  if (!billingEnabled) return sendJson(res, 400, { error: { message: 'Billing is not configured.' } });
+
+  const session = getSession(req);
+  if (!session || !session.uid) return sendJson(res, 401, { error: { message: 'Not signed in' } });
+  const user = await getUser(session.uid);
+  if (!user) return sendJson(res, 404, { error: { message: 'Account not found' } });
+  if (user.plan === 'pro') return sendJson(res, 200, { alreadyPro: true });
+
+  const base = appUrl(req);
+  try {
+    const checkout = await createCheckoutSession({
+      uid: user.uid,
+      email: user.email,
+      successUrl: `${base}/app.html?upgraded=1&session_id={CHECKOUT_SESSION_ID}`,
+      cancelUrl: `${base}/app.html?upgrade=cancelled`
+    });
+    sendJson(res, 200, { url: checkout.url });
+  } catch (error) {
+    sendJson(res, 502, { error: { message: String((error && error.message) || error) } });
+  }
+}

--- a/dashboard/api/billing/confirm.js
+++ b/dashboard/api/billing/confirm.js
@@ -1,0 +1,32 @@
+// Fulfillment on return from Stripe Checkout. Verifies the session server-side
+// (no webhook needed): if it is paid and belongs to the signed-in user, mark pro.
+
+import { sendJson, methodNotAllowed } from '../_lib/http.js';
+import { getSession } from '../_lib/session.js';
+import { setPlan } from '../_lib/users.js';
+import { billingEnabled, appUrl } from '../_lib/config.js';
+import { getCheckoutSession } from '../_lib/stripe.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST' && req.method !== 'GET') return methodNotAllowed(res, 'POST, GET');
+  if (!billingEnabled) return sendJson(res, 400, { error: { message: 'Billing is not configured.' } });
+
+  const session = getSession(req);
+  if (!session || !session.uid) return sendJson(res, 401, { error: { message: 'Not signed in' } });
+
+  const url = new URL(req.url, appUrl(req));
+  const sessionId = url.searchParams.get('session_id');
+  if (!sessionId) return sendJson(res, 400, { error: { message: 'Missing session_id' } });
+
+  try {
+    const checkout = await getCheckoutSession(sessionId);
+    const paid = checkout.payment_status === 'paid' || checkout.status === 'complete';
+    if (paid && checkout.client_reference_id === session.uid) {
+      await setPlan(session.uid, 'pro');
+      return sendJson(res, 200, { plan: 'pro' });
+    }
+    sendJson(res, 200, { plan: 'free', paid: false });
+  } catch (error) {
+    sendJson(res, 502, { error: { message: String((error && error.message) || error) } });
+  }
+}

--- a/dashboard/api/chat/completions.js
+++ b/dashboard/api/chat/completions.js
@@ -1,0 +1,53 @@
+// The metered proxy. The CLI points SKILLCHECK_API_URL at `<app>/api`, so the
+// OpenAI SDK posts here. We authenticate the Skillcheck key, meter the run, then
+// forward to NVIDIA with the server-side key and return the response unchanged.
+
+import { sendJson, methodNotAllowed, proxyCors, bearerToken, readJsonBody } from '../_lib/http.js';
+import { uidForApiKey, getUser, consumeRun } from '../_lib/users.js';
+import { forwardChatCompletion } from '../_lib/nvidia.js';
+import { NVIDIA_API_KEY, appUrl } from '../_lib/config.js';
+
+export default async function handler(req, res) {
+  proxyCors(res);
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+  if (req.method !== 'POST') return methodNotAllowed(res, 'POST, OPTIONS');
+  if (!NVIDIA_API_KEY) return sendJson(res, 500, { error: { message: 'Server is missing NVIDIA_API_KEY.' } });
+
+  const key = bearerToken(req);
+  if (!key) {
+    return sendJson(res, 401, {
+      error: { message: 'Missing API key. Get one from the Skillcheck dashboard and set SKILLCHECK_TOKEN.', type: 'no_key' }
+    });
+  }
+  const uid = await uidForApiKey(key);
+  if (!uid) return sendJson(res, 401, { error: { message: 'Invalid Skillcheck API key.', type: 'invalid_key' } });
+  const user = await getUser(uid);
+  if (!user) return sendJson(res, 401, { error: { message: 'Account not found for this key.', type: 'invalid_key' } });
+
+  const runId = String(req.headers['x-skillcheck-run'] || '').trim();
+  const meter = await consumeRun(uid, runId, user.plan);
+  if (!meter.allowed) {
+    return sendJson(res, 402, {
+      error: {
+        message: `You've used all ${meter.limit} free Skillcheck runs. Upgrade to keep going at ${appUrl(req)}/app.html`,
+        type: 'quota_exceeded',
+        upgrade_url: `${appUrl(req)}/app.html`
+      }
+    });
+  }
+
+  const body = await readJsonBody(req);
+  try {
+    const result = await forwardChatCompletion(body);
+    res.statusCode = result.status;
+    res.setHeader('content-type', result.contentType);
+    res.setHeader('x-skillcheck-runs-used', String(meter.used));
+    res.end(result.text);
+  } catch (error) {
+    sendJson(res, 502, { error: { message: 'Upstream model provider error.', detail: String((error && error.message) || error) } });
+  }
+}

--- a/dashboard/api/health.js
+++ b/dashboard/api/health.js
@@ -1,0 +1,6 @@
+import { sendJson, methodNotAllowed } from './_lib/http.js';
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res, 'GET');
+  sendJson(res, 200, { ok: true, service: 'skillcheck', time: new Date().toISOString() });
+}

--- a/dashboard/api/key/rotate.js
+++ b/dashboard/api/key/rotate.js
@@ -1,0 +1,14 @@
+import { sendJson, methodNotAllowed } from '../_lib/http.js';
+import { getSession } from '../_lib/session.js';
+import { rotateApiKey } from '../_lib/users.js';
+import { maskApiKey } from '../_lib/keys.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return methodNotAllowed(res, 'POST');
+  const session = getSession(req);
+  if (!session || !session.uid) return sendJson(res, 401, { error: { message: 'Not signed in' } });
+
+  const user = await rotateApiKey(session.uid);
+  if (!user) return sendJson(res, 404, { error: { message: 'Account not found' } });
+  sendJson(res, 200, { apiKey: user.apiKey, apiKeyMasked: maskApiKey(user.apiKey) });
+}

--- a/dashboard/api/me.js
+++ b/dashboard/api/me.js
@@ -1,0 +1,28 @@
+import { sendJson, methodNotAllowed } from './_lib/http.js';
+import { getSession } from './_lib/session.js';
+import { getUser, getRunsUsed, runLimitFor } from './_lib/users.js';
+import { billingEnabled, FREE_RUNS } from './_lib/config.js';
+import { maskApiKey } from './_lib/keys.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return methodNotAllowed(res, 'GET');
+  const session = getSession(req);
+  if (!session || !session.uid) return sendJson(res, 401, { error: { message: 'Not signed in' } });
+
+  const user = await getUser(session.uid);
+  if (!user) return sendJson(res, 401, { error: { message: 'Account not found' } });
+
+  const runsUsed = await getRunsUsed(user.uid);
+  const limit = runLimitFor(user.plan);
+  sendJson(res, 200, {
+    email: user.email,
+    name: user.name,
+    plan: user.plan,
+    apiKey: user.apiKey,
+    apiKeyMasked: maskApiKey(user.apiKey),
+    runsUsed,
+    runsLimit: Number.isFinite(limit) ? limit : null,
+    freeRuns: FREE_RUNS,
+    billingEnabled
+  });
+}

--- a/dashboard/app.html
+++ b/dashboard/app.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Skillcheck — Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/assets/styles.css" />
+  </head>
+  <body>
+    <div class="util">
+      <div class="wrap">
+        <span id="utilEmail">Skillcheck Cloud</span>
+        <a href="/api/auth/logout">Sign out</a>
+      </div>
+    </div>
+
+    <nav class="nav">
+      <div class="wrap">
+        <a class="brand" href="/">
+          <span class="mark" aria-hidden="true">
+            <svg width="26" height="18" viewBox="0 0 26 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M4 0H12L8 18H0L4 0Z" fill="#024ad8" />
+              <path d="M16 0H24L20 18H12L16 0Z" fill="#296ef9" />
+            </svg>
+          </span>
+          Skillcheck
+        </a>
+        <div class="spacer"></div>
+        <div class="right">
+          <span id="planBadge" class="badge badge-outline">Free</span>
+          <a class="btn btn-outline-ink btn-sm" href="/api/auth/logout">Sign out</a>
+        </div>
+      </div>
+    </nav>
+
+    <main class="wrap" style="padding-top:40px; padding-bottom:64px">
+      <div class="eyebrow">Dashboard</div>
+      <h1 style="font-size:44px">Your API key</h1>
+      <p class="muted" style="margin-top:8px">Use this key as <code>SKILLCHECK_TOKEN</code>. It maps to our server-side model provider key — keep it private.</p>
+
+      <div id="loading" class="muted" style="margin-top:32px">Loading…</div>
+
+      <div id="content" style="display:none; margin-top:32px">
+        <div class="dash-grid">
+          <div class="stack">
+            <div class="card">
+              <h3>Skillcheck API key</h3>
+              <div class="keyfield" style="margin-top:12px">
+                <code id="apiKey">sk_live_…</code>
+                <button class="btn btn-outline-ink btn-sm" id="revealBtn">Reveal</button>
+                <button class="btn btn-primary btn-sm" id="copyKeyBtn">Copy</button>
+              </div>
+              <div style="margin-top:14px">
+                <button class="btn-text" id="rotateBtn">Rotate key</button>
+                <span class="fine" style="margin-left:8px">Rotating invalidates the old key immediately.</span>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="usage-head">
+                <h3>Usage</h3>
+                <span id="usageCount" class="muted">0 / 10 runs</span>
+              </div>
+              <div class="bar"><div class="bar-fill" id="usageBar"></div></div>
+              <div id="upgradeRow" style="margin-top:18px; display:none">
+                <button class="btn btn-primary" id="upgradeBtn">Upgrade to Pro</button>
+                <span class="fine" id="upgradeNote" style="margin-left:8px"></span>
+              </div>
+              <div id="proRow" style="margin-top:18px; display:none">
+                <span class="badge badge-pro">Pro — unlimited runs</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <h3>Quickstart</h3>
+            <p class="muted" style="margin-top:8px">Paste these into your terminal, then check any skill.</p>
+            <div class="code" id="commands" style="margin-top:14px"><span id="commandsText"></span><button class="copy" id="copyCmd">Copy</button></div>
+            <p class="fine" style="margin-top:12px">Prefer interactive setup? Run <code>skillcheck setup</code> and paste the URL and key when asked.</p>
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:24px">
+          <h3>Quick check in the browser</h3>
+          <p class="muted" style="margin-top:8px">
+            Runs your task once with and once without the skill so you can see the contrast. This preview does not consume a run —
+            for the real verdict (N tasks × K trials, blind grading, bootstrap CI) use <code>skillcheck check</code>.
+          </p>
+          <label for="skill">Skill instructions</label>
+          <textarea id="skill" placeholder="Paste the body of your SKILL.md here…"></textarea>
+          <label for="task">Task prompt</label>
+          <textarea id="task" placeholder="A concrete task the skill should help with…" style="min-height:64px"></textarea>
+          <div style="margin-top:16px; display:flex; gap:12px; align-items:center; flex-wrap:wrap">
+            <button class="btn btn-ink" id="runBtn">Run with vs without skill</button>
+            <span id="runStatus" class="status"></span>
+          </div>
+          <div class="preview-grid">
+            <div class="arm">
+              <h4>With skill</h4>
+              <div id="withBody" class="body"></div>
+            </div>
+            <div class="arm">
+              <h4>Without skill</h4>
+              <div id="noBody" class="body"></div>
+            </div>
+          </div>
+          <p class="fine" id="overhead" style="margin-top:10px"></p>
+        </div>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <div class="wrap">
+        <div class="legal">© <span id="year"></span> Skillcheck. Keep your API key private.</div>
+      </div>
+    </footer>
+
+    <script src="/assets/app.js"></script>
+  </body>
+</html>

--- a/dashboard/assets/app.js
+++ b/dashboard/assets/app.js
@@ -1,0 +1,184 @@
+// Skillcheck dashboard logic: load account, show key + usage + commands, rotate,
+// upgrade, and an in-browser with/without-skill preview.
+(function () {
+  var $ = function (id) { return document.getElementById(id); };
+  var apiBase = location.origin + '/api';
+  var state = { fullKey: '', revealed: false, plan: 'free' };
+
+  var y = $('year'); if (y) y.textContent = String(new Date().getFullYear());
+
+  function copyText(text, done) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done, function () { fallback(text, done); });
+    } else { fallback(text, done); }
+  }
+  function fallback(text, done) {
+    var ta = document.createElement('textarea');
+    ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+    document.body.appendChild(ta); ta.select();
+    try { document.execCommand('copy'); } catch (e) {}
+    document.body.removeChild(ta); if (done) done();
+  }
+  function flash(btn, label) {
+    var prev = btn.textContent; btn.textContent = label || 'Copied';
+    setTimeout(function () { btn.textContent = prev; }, 1200);
+  }
+  function mask(key) {
+    return key && key.length > 15 ? key.slice(0, 11) + '…' + key.slice(-4) : key;
+  }
+
+  function renderKey() {
+    $('apiKey').textContent = state.revealed ? state.fullKey : mask(state.fullKey);
+    $('revealBtn').textContent = state.revealed ? 'Hide' : 'Reveal';
+  }
+
+  function renderCommands() {
+    var text =
+      'npm install -g @sx4im/skillcheck\n' +
+      'export SKILLCHECK_API_URL=' + apiBase + '\n' +
+      'export SKILLCHECK_TOKEN=' + state.fullKey + '\n' +
+      'skillcheck check ./SKILL.md';
+    $('commandsText').textContent = text;
+  }
+
+  function renderUsage(me) {
+    var used = me.runsUsed || 0;
+    var limit = me.runsLimit; // null => unlimited
+    if (limit === null) {
+      $('usageCount').textContent = used + ' runs · unlimited';
+      $('usageBar').style.width = '12%';
+    } else {
+      $('usageCount').textContent = used + ' / ' + limit + ' runs';
+      var pct = Math.min(100, Math.round((used / limit) * 100));
+      var bar = $('usageBar');
+      bar.style.width = pct + '%';
+      if (used >= limit) bar.classList.add('full');
+    }
+  }
+
+  function renderPlan(me) {
+    state.plan = me.plan;
+    var badge = $('planBadge');
+    if (me.plan === 'pro') {
+      badge.textContent = 'Pro';
+      badge.className = 'badge badge-pro';
+      $('proRow').style.display = 'block';
+      $('upgradeRow').style.display = 'none';
+    } else {
+      badge.textContent = 'Free';
+      badge.className = 'badge badge-outline';
+      $('proRow').style.display = 'none';
+      if (me.billingEnabled) {
+        $('upgradeRow').style.display = 'block';
+        if ((me.runsUsed || 0) >= (me.runsLimit || 0)) {
+          $('upgradeNote').textContent = 'You are out of free runs.';
+        }
+      } else {
+        $('upgradeRow').style.display = 'none';
+      }
+    }
+  }
+
+  function render(me) {
+    $('loading').style.display = 'none';
+    $('content').style.display = 'block';
+    $('utilEmail').textContent = me.email || 'Skillcheck Cloud';
+    state.fullKey = me.apiKey || '';
+    renderKey();
+    renderCommands();
+    renderUsage(me);
+    renderPlan(me);
+  }
+
+  function loadMe() {
+    return fetch(apiBase + '/me', { headers: { accept: 'application/json' } })
+      .then(function (r) {
+        if (r.status === 401) { location.href = '/'; return null; }
+        return r.json();
+      })
+      .then(function (me) { if (me) render(me); });
+  }
+
+  // --- Upgrade confirmation on return from Stripe ---
+  function maybeConfirmUpgrade() {
+    var params = new URLSearchParams(location.search);
+    if (params.get('upgraded') === '1' && params.get('session_id')) {
+      return fetch(apiBase + '/billing/confirm?session_id=' + encodeURIComponent(params.get('session_id')), { method: 'POST' })
+        .then(function () {})
+        .catch(function () {})
+        .then(function () { history.replaceState({}, '', '/app.html'); });
+    }
+    return Promise.resolve();
+  }
+
+  // --- Events ---
+  $('revealBtn').addEventListener('click', function () { state.revealed = !state.revealed; renderKey(); });
+  $('copyKeyBtn').addEventListener('click', function () { copyText(state.fullKey, function () { flash($('copyKeyBtn')); }); });
+  $('copyCmd').addEventListener('click', function () { copyText($('commandsText').textContent, function () { flash($('copyCmd')); }); });
+
+  $('rotateBtn').addEventListener('click', function () {
+    if (!confirm('Rotate your API key? The current key stops working immediately.')) return;
+    fetch(apiBase + '/key/rotate', { method: 'POST' })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.apiKey) { state.fullKey = data.apiKey; state.revealed = true; renderKey(); renderCommands(); }
+      });
+  });
+
+  $('upgradeBtn').addEventListener('click', function () {
+    $('upgradeBtn').disabled = true;
+    fetch(apiBase + '/billing/checkout', { method: 'POST' })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.url) location.href = data.url;
+        else { $('upgradeBtn').disabled = false; $('upgradeNote').textContent = (data.error && data.error.message) || 'Could not start checkout.'; }
+      })
+      .catch(function () { $('upgradeBtn').disabled = false; });
+  });
+
+  // --- Live preview ---
+  function extractContent(data) {
+    var m = data && data.choices && data.choices[0] && data.choices[0].message;
+    if (!m) return '';
+    return m.content || m.reasoning_content || m.refusal || '';
+  }
+  function callModel(messages) {
+    return fetch(apiBase + '/chat/completions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer ' + state.fullKey },
+      body: JSON.stringify({ model: 'qwen/qwen3-next-80b-a3b-instruct', messages: messages, temperature: 0.7, max_tokens: 1200, stream: false })
+    }).then(function (r) {
+      return r.text().then(function (text) {
+        if (!r.ok) throw new Error('HTTP ' + r.status + ': ' + text.slice(0, 200));
+        var data; try { data = JSON.parse(text); } catch (e) { throw new Error('Non-JSON response'); }
+        return { content: extractContent(data), usage: data.usage || {} };
+      });
+    });
+  }
+  $('runBtn').addEventListener('click', function () {
+    var skill = $('skill').value.trim();
+    var task = $('task').value.trim();
+    var status = $('runStatus');
+    if (!skill || !task) { status.className = 'status err'; status.textContent = 'Add both a skill and a task.'; return; }
+    var withMessages = [
+      { role: 'system', content: 'You are completing an evaluation task. Apply the following skill instructions when relevant.\n\n' + skill },
+      { role: 'user', content: task }
+    ];
+    var noMessages = [{ role: 'user', content: task }];
+    $('runBtn').disabled = true;
+    status.className = 'status'; status.textContent = 'Running both arms…';
+    $('withBody').textContent = ''; $('noBody').textContent = ''; $('overhead').textContent = '';
+    Promise.all([callModel(withMessages), callModel(noMessages)])
+      .then(function (res) {
+        $('withBody').textContent = res[0].content || '(empty)';
+        $('noBody').textContent = res[1].content || '(empty)';
+        var overhead = (res[0].usage.prompt_tokens || 0) - (res[1].usage.prompt_tokens || 0);
+        $('overhead').textContent = 'Token cost of injecting the skill: ' + (overhead > 0 ? '+' + overhead : overhead) + ' prompt tokens.';
+        status.className = 'status ok'; status.textContent = 'Done.';
+      })
+      .catch(function (e) { status.className = 'status err'; status.textContent = e.message; })
+      .then(function () { $('runBtn').disabled = false; });
+  });
+
+  maybeConfirmUpgrade().then(loadMe);
+})();

--- a/dashboard/assets/landing.js
+++ b/dashboard/assets/landing.js
@@ -1,0 +1,32 @@
+// Landing-page helpers: copy buttons + footer year.
+(function () {
+  var year = document.getElementById('year');
+  if (year) year.textContent = String(new Date().getFullYear());
+
+  function copyText(text, done) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done, function () { fallback(text, done); });
+    } else {
+      fallback(text, done);
+    }
+  }
+  function fallback(text, done) {
+    var ta = document.createElement('textarea');
+    ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+    document.body.appendChild(ta); ta.select();
+    try { document.execCommand('copy'); } catch (e) {}
+    document.body.removeChild(ta); if (done) done();
+  }
+
+  document.querySelectorAll('.copy').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var host = document.getElementById(btn.getAttribute('data-copy'));
+      if (!host) return;
+      var text = host.childNodes[0] ? host.childNodes[0].textContent : host.textContent;
+      copyText(text.trim(), function () {
+        var prev = btn.textContent; btn.textContent = 'Copied';
+        setTimeout(function () { btn.textContent = prev; }, 1200);
+      });
+    });
+  });
+})();

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -1,0 +1,231 @@
+/* Skillcheck dashboard — HP-inspired design system (see DESIGN.md).
+   One blue CTA (#024ad8), ink #1a1a1a, Inter (Forma DJR Micro substitute),
+   16px cards / 4px buttons, dark slabs top and bottom. */
+
+:root {
+  --primary: #024ad8;
+  --primary-bright: #296ef9;
+  --primary-deep: #0e3191;
+  --primary-soft: #c9e0fc;
+  --on-primary: #ffffff;
+
+  --ink: #1a1a1a;
+  --ink-deep: #000000;
+  --ink-soft: #292929;
+  --charcoal: #3d3d3d;
+  --graphite: #636363;
+
+  --canvas: #ffffff;
+  --cloud: #f7f7f7;
+  --fog: #e8e8e8;
+  --steel: #c2c2c2;
+  --hairline: #e8e8e8;
+  --error: #b3262b;
+
+  --r-md: 4px;
+  --r-lg: 8px;
+  --r-xl: 16px;
+  --r-pill: 9999px;
+
+  --lift: 0 2px 8px rgba(26, 26, 26, 0.08);
+  --modal: 0 8px 24px rgba(26, 26, 26, 0.12);
+
+  --max: 1100px;
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: var(--font);
+  font-size: 16px;
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3 { font-weight: 500; line-height: 1.0; margin: 0; }
+h1 { font-size: 56px; letter-spacing: -0.5px; }
+h2 { font-size: 32px; }
+h3 { font-size: 20px; line-height: 1.17; }
+p { margin: 0; }
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.wrap { max-width: var(--max); margin: 0 auto; padding: 0 24px; }
+.section { padding: 80px 0; }
+.muted { color: var(--charcoal); }
+.fine { color: var(--graphite); font-size: 12px; line-height: 1.33; }
+.eyebrow {
+  font-size: 12.6px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+  color: var(--primary); margin-bottom: 12px;
+}
+
+/* ---------- Utility strip (dark, top) ---------- */
+.util {
+  background: var(--ink); color: var(--on-primary);
+  font-size: 14px; height: 36px;
+}
+.util .wrap { display: flex; align-items: center; justify-content: space-between; height: 36px; }
+.util a { color: var(--on-primary); opacity: 0.85; }
+.util a:hover { opacity: 1; }
+
+/* ---------- Top nav ---------- */
+.nav {
+  background: var(--canvas); height: 64px;
+  border-bottom: 1px solid var(--hairline);
+  position: sticky; top: 0; z-index: 20;
+}
+.nav .wrap { display: flex; align-items: center; height: 64px; gap: 24px; }
+.brand { display: inline-flex; align-items: center; gap: 10px; color: var(--ink); font-weight: 600; font-size: 20px; }
+.brand:hover { text-decoration: none; }
+.brand .mark { display: inline-block; }
+.nav .links { display: flex; gap: 4px; margin-left: 8px; }
+.nav .links a { color: var(--ink); padding: 8px 16px; font-size: 16px; }
+.nav .spacer { flex: 1; }
+.nav .right { display: flex; align-items: center; gap: 16px; }
+
+/* ---------- Buttons ---------- */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  height: 44px; padding: 0 24px; border-radius: var(--r-md);
+  font-size: 14px; font-weight: 600; letter-spacing: 0.7px; text-transform: uppercase;
+  border: 1px solid transparent; cursor: pointer; background: none;
+  font-family: var(--font); white-space: nowrap; text-decoration: none;
+}
+.btn:hover { text-decoration: none; }
+.btn-primary { background: var(--primary); color: var(--on-primary); }
+.btn-primary:hover { background: var(--primary-deep); }
+.btn-primary:disabled { background: var(--steel); cursor: not-allowed; }
+.btn-ink { background: var(--ink); color: var(--on-primary); }
+.btn-ink:hover { background: var(--ink-soft); }
+.btn-outline { background: var(--canvas); color: var(--primary); border-color: var(--primary); }
+.btn-outline:hover { background: var(--primary-soft); }
+.btn-outline-ink { background: var(--canvas); color: var(--ink); border-color: var(--ink); }
+.btn-outline-ink:hover { background: var(--cloud); }
+.btn-sm { height: 36px; padding: 0 16px; font-size: 12.6px; }
+.btn-text { color: var(--primary); font-weight: 500; text-transform: none; letter-spacing: 0; padding: 4px 0; height: auto; }
+
+/* ---------- Bands ---------- */
+.band-cloud { background: var(--cloud); }
+.band-fog { background: var(--fog); }
+.band-ink { background: var(--ink); color: var(--on-primary); }
+.band-ink h2, .band-ink h1 { color: var(--on-primary); }
+.band-ink .eyebrow { color: var(--primary-bright); }
+
+/* ---------- Hero ---------- */
+.hero { position: relative; overflow: hidden; }
+.hero h1 { font-size: 72px; max-width: 760px; }
+.hero p.lead { font-size: 18px; line-height: 1.33; color: var(--charcoal); max-width: 560px; margin-top: 20px; }
+.hero .cta-row { display: flex; gap: 12px; margin-top: 32px; flex-wrap: wrap; }
+.chevrons::before, .chevrons::after {
+  content: ''; position: absolute; top: -40px; bottom: -40px; width: 120px;
+  background: var(--primary); transform: skewX(-18deg); z-index: 0; opacity: 0.9;
+}
+.chevrons::before { left: -70px; }
+.chevrons::after { right: -70px; background: var(--primary-soft); }
+.hero .wrap { position: relative; z-index: 1; }
+
+/* ---------- Cards ---------- */
+.grid { display: grid; gap: 24px; }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.card {
+  background: var(--canvas); border-radius: var(--r-xl); padding: 24px;
+  box-shadow: var(--lift); border: 1px solid var(--hairline);
+}
+.card.flat { box-shadow: none; }
+.card .num {
+  width: 32px; height: 32px; border-radius: var(--r-pill); background: var(--primary);
+  color: var(--on-primary); display: grid; place-items: center; font-weight: 600; margin-bottom: 16px;
+}
+.card h3 { margin-bottom: 8px; }
+.card p { color: var(--charcoal); font-size: 16px; }
+
+/* ---------- Pricing ---------- */
+.tiers { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; max-width: 720px; margin: 0 auto; }
+.tier { background: var(--canvas); border-radius: var(--r-xl); padding: 32px; box-shadow: var(--lift); border: 1px solid var(--hairline); }
+.tier-featured { border-top: 3px solid var(--primary); }
+.tier .name { font-size: 24px; font-weight: 500; }
+.tier .price { font-size: 44px; font-weight: 500; margin: 12px 0 4px; }
+.tier-featured .price { color: var(--primary); }
+.tier .price small { font-size: 16px; color: var(--graphite); font-weight: 400; }
+.tier ul { list-style: none; padding: 0; margin: 20px 0; }
+.tier li { padding: 8px 0; border-top: 1px solid var(--hairline); font-size: 16px; color: var(--charcoal); }
+.tier li:first-child { border-top: none; }
+
+/* ---------- Code blocks ---------- */
+.code {
+  position: relative; background: var(--ink); color: #e7eefc; border-radius: var(--r-lg);
+  padding: 16px 18px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13.5px;
+  line-height: 1.6; overflow-x: auto; white-space: pre;
+}
+.code .copy {
+  position: absolute; top: 10px; right: 10px; height: 28px; padding: 0 10px;
+  background: #21305a; color: #cdd8f5; border: 1px solid #33457a; border-radius: var(--r-md);
+  font-size: 12px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; cursor: pointer;
+}
+.code .copy:hover { background: #2c3e72; }
+
+/* ---------- Footer ---------- */
+.footer { background: var(--ink); color: var(--on-primary); padding: 64px 0 40px; }
+.footer a { color: var(--on-primary); opacity: 0.82; font-size: 16px; }
+.footer a:hover { opacity: 1; }
+.footer .cols { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 40px; }
+.footer h4 { font-size: 16px; font-weight: 500; margin: 0 0 16px; }
+.footer .legal { color: var(--steel); font-size: 12px; margin-top: 40px; border-top: 1px solid #2c2c2c; padding-top: 24px; }
+
+/* ---------- Forms / dashboard ---------- */
+label { display: block; font-size: 14px; font-weight: 500; margin: 16px 0 6px; }
+label .hint { color: var(--graphite); font-weight: 400; }
+input[type=text], input[type=password], textarea {
+  width: 100%; height: 44px; padding: 12px 16px; border: 1px solid var(--steel);
+  border-radius: var(--r-md); font-family: var(--font); font-size: 16px; color: var(--ink); background: var(--canvas);
+}
+textarea { height: auto; min-height: 96px; resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13.5px; }
+input:focus, textarea:focus { outline: none; border-color: var(--ink); }
+
+.badge { display: inline-flex; align-items: center; gap: 6px; border-radius: var(--r-lg); padding: 6px 12px; font-size: 14px; font-weight: 500; }
+.badge-ink { background: var(--ink); color: var(--on-primary); }
+.badge-outline { background: var(--canvas); color: var(--ink); border: 1px solid var(--ink); }
+.badge-pro { background: var(--primary); color: var(--on-primary); }
+
+.keyfield { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.keyfield code {
+  flex: 1; min-width: 240px; background: var(--cloud); border: 1px solid var(--hairline); border-radius: var(--r-md);
+  padding: 10px 14px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 14px; color: var(--ink);
+  overflow-x: auto; white-space: nowrap;
+}
+
+.usage-head { display: flex; justify-content: space-between; align-items: baseline; }
+.bar { height: 10px; background: var(--fog); border-radius: var(--r-pill); overflow: hidden; margin-top: 12px; }
+.bar-fill { height: 100%; background: var(--primary); border-radius: var(--r-pill); width: 0; transition: width 0.4s ease; }
+.bar-fill.full { background: var(--error); }
+
+.preview-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
+.arm h4 { margin: 0 0 6px; font-size: 14px; }
+.arm .body {
+  white-space: pre-wrap; background: var(--cloud); border: 1px solid var(--hairline); border-radius: var(--r-md);
+  padding: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; min-height: 64px;
+}
+.status { font-size: 14px; margin-top: 10px; min-height: 18px; }
+.status.err { color: var(--error); }
+.status.ok { color: var(--primary); }
+
+.dash-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+.stack > * + * { margin-top: 12px; }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+  .grid-3, .grid-2, .tiers, .preview-grid, .dash-grid, .footer .cols { grid-template-columns: 1fr; }
+  h1 { font-size: 40px; }
+  .hero h1 { font-size: 44px; }
+  h2 { font-size: 26px; }
+  .section { padding: 48px 0; }
+  .chevrons::before, .chevrons::after { display: none; }
+  .nav .links { display: none; }
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Skillcheck — does your agent skill actually help?</title>
+    <meta name="description" content="Measure whether an agent skill improves task performance. Sign in, get an API key with 10 free runs, and check any SKILL.md from the CLI." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/assets/styles.css" />
+  </head>
+  <body>
+    <div class="util">
+      <div class="wrap">
+        <span>Skillcheck Cloud — forced-injection A/B evaluation for agent skills</span>
+        <a href="/api/auth/login">Sign in</a>
+      </div>
+    </div>
+
+    <nav class="nav">
+      <div class="wrap">
+        <a class="brand" href="/">
+          <span class="mark" aria-hidden="true">
+            <svg width="26" height="18" viewBox="0 0 26 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M4 0H12L8 18H0L4 0Z" fill="#024ad8" />
+              <path d="M16 0H24L20 18H12L16 0Z" fill="#296ef9" />
+            </svg>
+          </span>
+          Skillcheck
+        </a>
+        <div class="links">
+          <a href="#how">How it works</a>
+          <a href="#pricing">Pricing</a>
+          <a href="https://github.com/sx4im/skillcheck">Docs</a>
+        </div>
+        <div class="spacer"></div>
+        <div class="right">
+          <a class="btn btn-primary" href="/api/auth/login">Sign in with GitHub</a>
+        </div>
+      </div>
+    </nav>
+
+    <header class="hero section">
+      <div class="chevrons"></div>
+      <div class="wrap">
+        <div class="eyebrow">Agent skill evaluation</div>
+        <h1>Does your skill actually help?</h1>
+        <p class="lead">
+          Skillcheck runs a forced-injection A/B test: your runner model solves generated tasks
+          with and without the skill, grades blind, and returns an effect in percentage points
+          with a confidence interval. Sign in, get an API key, and check any skill from the CLI.
+        </p>
+        <div class="cta-row">
+          <a class="btn btn-primary" href="/api/auth/login">Get your API key</a>
+          <a class="btn btn-outline-ink" href="https://github.com/sx4im/skillcheck/blob/main/METHODOLOGY.md">View the methodology</a>
+        </div>
+        <div style="margin-top:40px; max-width:620px">
+          <div class="code" id="installCode">npm install -g @sx4im/skillcheck
+skillcheck check ./SKILL.md<button class="copy" data-copy="installCode">Copy</button></div>
+        </div>
+      </div>
+    </header>
+
+    <section class="band-cloud section" id="how">
+      <div class="wrap">
+        <div class="eyebrow">How it works</div>
+        <h2>Three steps to a verdict</h2>
+        <div class="grid grid-3" style="margin-top:40px">
+          <div class="card">
+            <div class="num">1</div>
+            <h3>Sign in with GitHub</h3>
+            <p>No setup, no credit card. We create your account and issue a Skillcheck API key tied to it.</p>
+          </div>
+          <div class="card">
+            <div class="num">2</div>
+            <h3>Get 10 free runs</h3>
+            <p>Your key includes 10 free <code>skillcheck check</code> runs. The model provider key stays on our server — never in your terminal.</p>
+          </div>
+          <div class="card">
+            <div class="num">3</div>
+            <h3>Run skillcheck</h3>
+            <p>Paste two commands, point the CLI at your key, and measure any SKILL.md, AGENTS.md, CLAUDE.md, or .cursorrules.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="pricing">
+      <div class="wrap" style="text-align:center">
+        <div class="eyebrow">Pricing</div>
+        <h2>Start free. Upgrade when it pays off.</h2>
+        <div class="tiers" style="margin-top:40px; text-align:left">
+          <div class="tier">
+            <div class="name">Free</div>
+            <div class="price">$0</div>
+            <ul>
+              <li>10 Skillcheck runs included</li>
+              <li>Full CLI: check, eval, verify</li>
+              <li>Blind grading + bootstrap CI</li>
+              <li>Community support</li>
+            </ul>
+            <a class="btn btn-outline" href="/api/auth/login" style="width:100%">Get started</a>
+          </div>
+          <div class="tier tier-featured">
+            <div class="name">Pro</div>
+            <div class="price">$19 <small>/ one-time</small></div>
+            <ul>
+              <li>Everything in Free</li>
+              <li>Unlimited Skillcheck runs</li>
+              <li>Corpus &amp; rot reporting</li>
+              <li>Priority model capacity</li>
+            </ul>
+            <a class="btn btn-primary" href="/api/auth/login" style="width:100%">Upgrade after sign-in</a>
+          </div>
+        </div>
+        <p class="fine" style="margin-top:20px">Price shown is an example — set your own in Stripe. Upgrade lives in your dashboard after sign-in.</p>
+      </div>
+    </section>
+
+    <section class="band-ink section">
+      <div class="wrap" style="text-align:center">
+        <h2>Ready to measure your skills?</h2>
+        <p class="lead" style="color:#c9d3ea; margin:16px auto 28px">Sign in with GitHub and get your API key in seconds.</p>
+        <a class="btn btn-primary" href="/api/auth/login">Get your API key</a>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <div class="wrap">
+        <div class="cols">
+          <div>
+            <a class="brand" href="/" style="color:#fff">
+              <span class="mark" aria-hidden="true">
+                <svg width="26" height="18" viewBox="0 0 26 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M4 0H12L8 18H0L4 0Z" fill="#024ad8" />
+                  <path d="M16 0H24L20 18H12L16 0Z" fill="#296ef9" />
+                </svg>
+              </span>
+              Skillcheck
+            </a>
+            <p style="color:#aab3c9; margin-top:12px; max-width:280px">Measure whether an agent skill actually improves task performance.</p>
+          </div>
+          <div>
+            <h4>Product</h4>
+            <div class="stack">
+              <a href="#how">How it works</a>
+              <a href="#pricing">Pricing</a>
+              <a href="/api/auth/login">Sign in</a>
+            </div>
+          </div>
+          <div>
+            <h4>Resources</h4>
+            <div class="stack">
+              <a href="https://github.com/sx4im/skillcheck">GitHub</a>
+              <a href="https://github.com/sx4im/skillcheck/blob/main/METHODOLOGY.md">Methodology</a>
+              <a href="https://www.npmjs.com/package/@sx4im/skillcheck">npm</a>
+            </div>
+          </div>
+        </div>
+        <div class="legal">© <span id="year"></span> Skillcheck. Built on the @sx4im/skillcheck CLI.</div>
+      </div>
+    </footer>
+
+    <script src="/assets/landing.js"></script>
+  </body>
+</html>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "skillcheck-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Skillcheck Cloud dashboard + metered proxy (zero-dependency, deploys on Vercel).",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "node test/smoke.mjs && node test/proxy.mjs"
+  }
+}

--- a/dashboard/test/proxy.mjs
+++ b/dashboard/test/proxy.mjs
@@ -1,0 +1,87 @@
+// In-process integration test for the metered proxy handler.
+// Stubs the upstream provider (global fetch) so it runs offline.
+//   node test/proxy.mjs
+
+import assert from 'node:assert/strict';
+
+process.env.NVIDIA_API_KEY = 'test-upstream-key';
+process.env.NVIDIA_BASE_URL = 'http://upstream.local/v1';
+process.env.FREE_RUNS = '10';
+// (no UPSTASH_* → in-memory store; no AUTH_SECRET → dev session secret)
+
+// Stub the upstream model call.
+let upstreamCalls = 0;
+const realFetch = globalThis.fetch;
+globalThis.fetch = async (url, init) => {
+  if (String(url).includes('upstream.local')) {
+    upstreamCalls += 1;
+    return {
+      status: 200,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify({ choices: [{ message: { content: 'ok' } }], usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 } })
+    };
+  }
+  return realFetch(url, init);
+};
+
+const { createOrGetUserFromGithub } = await import('../api/_lib/users.js');
+const handler = (await import('../api/chat/completions.js')).default;
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: '',
+    setHeader(name, value) { this.headers[name.toLowerCase()] = value; },
+    getHeader(name) { return this.headers[name.toLowerCase()]; },
+    end(chunk) { if (chunk) this.body += chunk; this.ended = true; }
+  };
+}
+async function call(key, runId) {
+  const req = {
+    method: 'POST',
+    headers: {
+      host: 'app.local',
+      'x-forwarded-proto': 'https',
+      ...(key ? { authorization: `Bearer ${key}` } : {}),
+      ...(runId ? { 'x-skillcheck-run': runId } : {})
+    },
+    body: { messages: [{ role: 'user', content: 'hi' }] }
+  };
+  const res = mockRes();
+  await handler(req, res);
+  let json = null;
+  try { json = JSON.parse(res.body); } catch {}
+  return { status: res.statusCode, json, headers: res.headers };
+}
+
+const user = await createOrGetUserFromGithub({ ghId: 'proxy-1', email: 'p@x.com', name: 'P' });
+
+// 1. Missing key → 401
+assert.equal((await call('', 'r1')).status, 401, 'missing key rejected');
+
+// 2. Invalid key → 401
+assert.equal((await call('sk_live_nope', 'r1')).status, 401, 'invalid key rejected');
+
+// 3. Ten valid runs forward and succeed
+for (let i = 1; i <= 10; i += 1) {
+  const r = await call(user.apiKey, `run-${i}`);
+  assert.equal(r.status, 200, `run ${i} forwarded`);
+  assert.equal(r.headers['x-skillcheck-runs-used'], String(i), `run ${i} usage header`);
+}
+
+// 4. Many calls within one run id only count once
+const before = upstreamCalls;
+for (let i = 0; i < 3; i += 1) await call(user.apiKey, 'run-3'); // existing run id
+assert.equal(upstreamCalls, before + 3, 'mid-run calls still forward');
+
+// 5. 11th distinct run → 402 quota
+const over = await call(user.apiKey, 'run-11');
+assert.equal(over.status, 402, '11th run blocked');
+assert.equal(over.json.error.type, 'quota_exceeded', '402 type');
+assert.match(over.json.error.upgrade_url, /\/app\.html$/, 'upgrade url present');
+
+// 6. Preview (no run id) still forwards and is not gated
+assert.equal((await call(user.apiKey, '')).status, 200, 'preview forwards');
+
+console.log('Proxy integration checks passed (upstream calls:', upstreamCalls + ').');

--- a/dashboard/test/smoke.mjs
+++ b/dashboard/test/smoke.mjs
@@ -1,0 +1,76 @@
+// Zero-dependency smoke test for the dashboard's core logic.
+// Runs against the in-memory store (no Upstash/env needed): `node test/smoke.mjs`.
+
+import assert from 'node:assert/strict';
+import { generateApiKey, hashApiKey, maskApiKey } from '../api/_lib/keys.js';
+import { createSessionToken, verifySessionToken } from '../api/_lib/session.js';
+import { createOrGetUserFromGithub, uidForApiKey, consumeRun, getRunsUsed, setPlan, rotateApiKey } from '../api/_lib/users.js';
+import { FREE_RUNS } from '../api/_lib/config.js';
+
+let passed = 0;
+function ok(label) { passed += 1; console.log('  ✓', label); }
+
+// --- keys ---
+const key = generateApiKey();
+assert.match(key, /^sk_live_[A-Za-z0-9_-]{20,}$/, 'key format');
+assert.equal(hashApiKey(key), hashApiKey(key), 'hash is deterministic');
+assert.notEqual(hashApiKey(key), key, 'hash is not the raw key');
+assert.ok(maskApiKey(key).includes('…') && maskApiKey(key).startsWith('sk_live_'), 'mask hides middle');
+ok('keys: generate / hash / mask');
+
+// --- session ---
+const token = createSessionToken({ uid: 'abc' });
+assert.equal(verifySessionToken(token).uid, 'abc', 'round-trips uid');
+assert.equal(verifySessionToken(token + 'x'), null, 'rejects tampered token');
+assert.equal(verifySessionToken('garbage'), null, 'rejects garbage');
+ok('session: sign / verify / tamper');
+
+// --- users + run metering ---
+const user = await createOrGetUserFromGithub({ ghId: 'gh-1', email: 'a@b.com', name: 'A' });
+assert.ok(user.apiKey.startsWith('sk_live_'), 'issued an api key');
+assert.equal(await uidForApiKey(user.apiKey), user.uid, 'key resolves to uid');
+assert.equal((await createOrGetUserFromGithub({ ghId: 'gh-1' })).uid, user.uid, 'returning user is stable');
+ok('users: create / lookup / idempotent');
+
+// 10 distinct runs allowed and counted
+for (let i = 1; i <= FREE_RUNS; i += 1) {
+  const r = await consumeRun(user.uid, `run-${i}`, 'free');
+  assert.equal(r.allowed, true, `run ${i} allowed`);
+  assert.equal(r.counted, true, `run ${i} counted`);
+}
+assert.equal(await getRunsUsed(user.uid), FREE_RUNS, 'used == FREE_RUNS');
+
+// repeating a run id within the same run does not consume another slot
+const repeat = await consumeRun(user.uid, 'run-1', 'free');
+assert.equal(repeat.allowed, true, 'repeat allowed');
+assert.equal(repeat.counted, false, 'repeat not counted');
+assert.equal(await getRunsUsed(user.uid), FREE_RUNS, 'used unchanged after repeat');
+
+// the 11th distinct run is blocked on the free plan
+const over = await consumeRun(user.uid, 'run-over', 'free');
+assert.equal(over.allowed, false, '11th run blocked');
+assert.equal(over.reason, 'quota_exceeded', 'blocked reason');
+assert.equal(await getRunsUsed(user.uid), FREE_RUNS, 'blocked run did not consume a slot');
+
+// requests without a run id are allowed and uncounted (dashboard preview)
+const preview = await consumeRun(user.uid, '', 'free');
+assert.equal(preview.allowed, true, 'preview allowed');
+assert.equal(preview.counted, false, 'preview not counted');
+ok('metering: 10 free runs, dedupe, gate at 11, uncounted preview');
+
+// upgrading to pro lifts the cap
+await setPlan(user.uid, 'pro');
+const pro = await consumeRun(user.uid, 'run-pro', 'pro');
+assert.equal(pro.allowed, true, 'pro run allowed past free limit');
+assert.equal(pro.counted, true, 'pro run counted');
+ok('metering: pro is unlimited');
+
+// rotating the key invalidates the old one
+const oldKey = user.apiKey;
+const rotated = await rotateApiKey(user.uid);
+assert.notEqual(rotated.apiKey, oldKey, 'new key differs');
+assert.equal(await uidForApiKey(oldKey), null, 'old key no longer resolves');
+assert.equal(await uidForApiKey(rotated.apiKey), user.uid, 'new key resolves');
+ok('keys: rotation invalidates the old key');
+
+console.log(`\nAll smoke checks passed (${passed} groups).`);

--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "api/chat/completions.js": { "maxDuration": 60 }
+  },
+  "rewrites": [
+    { "source": "/health", "destination": "/api/health" }
+  ]
+}

--- a/docs/skillcheck-cloud-build-plan.md
+++ b/docs/skillcheck-cloud-build-plan.md
@@ -1,0 +1,644 @@
+# Skillcheck Dashboard Plan
+
+This document is the build plan for a separate Skillcheck Cloud dashboard and API. The goal is:
+
+- Users install the CLI with one command.
+- On first CLI run, users paste the Skillcheck API URL.
+- Users can sign up in a dashboard.
+- Users can create a Skillcheck token.
+- The CLI calls your backend, not the upstream model provider directly.
+- Your upstream provider secret stays only on the backend.
+
+## Target Deployment
+
+Use two separate deploys:
+
+```text
+Vercel
+  app.skillcheck.yourdomain.com
+  Next.js dashboard, marketing, auth pages, API key management, usage UI
+
+Render
+  api.skillcheck.yourdomain.com
+  Node/Fastify or Hono API, OpenAI-compatible proxy, rate limits, usage tracking
+
+Postgres
+  Render Postgres or Neon/Supabase Postgres
+  Users, API keys, usage events, runs, billing state
+
+Redis
+  Upstash Redis or Render Key Value
+  Fast per-token and per-IP rate limits
+```
+
+The CLI setup URL should be:
+
+```bash
+https://api.skillcheck.yourdomain.com/v1
+```
+
+## Recommended Repos
+
+Build this separately from the CLI repo.
+
+```text
+skillcheck-dashboard/
+  apps/web/        Next.js dashboard deployed to Vercel
+  apps/api/        Node API deployed to Render
+  packages/db/     Prisma/Drizzle schema and migrations
+  packages/shared/ shared types, token helpers, validation schemas
+```
+
+If you want to move fast, a single repo with `apps/web` and `apps/api` is better than two repos because shared types and database migrations stay together.
+
+## Product Flow
+
+### User Flow
+
+1. User installs CLI:
+
+   ```bash
+   npm install -g @sx4im/skillcheck
+   ```
+
+2. User signs up on the dashboard.
+3. Dashboard shows onboarding:
+
+   ```bash
+   skillcheck setup
+   ```
+
+4. User pastes:
+
+   ```bash
+   https://api.skillcheck.yourdomain.com/v1
+   ```
+
+5. If private beta, dashboard also gives a token:
+
+   ```bash
+   export SKILLCHECK_TOKEN=sk_live_...
+   ```
+
+6. User runs:
+
+   ```bash
+   skillcheck
+   ```
+
+7. CLI opens file/folder picker and calls your backend.
+8. Dashboard usage page shows requests, tokens, cost estimate, verdict counts, and recent runs.
+
+### Admin Flow
+
+1. Admin logs into dashboard.
+2. Admin sees total usage, active users, failed requests, spend estimate.
+3. Admin can revoke tokens, ban abusive IPs, adjust quotas, and inspect error logs.
+
+## Frontend: Vercel Dashboard
+
+Use Next.js App Router.
+
+Recommended stack:
+
+```text
+Next.js
+TypeScript
+Tailwind CSS
+shadcn/ui or custom components
+Clerk for auth if you want fastest launch
+Stripe later for billing
+PostHog or simple internal analytics later
+```
+
+Pages:
+
+```text
+/
+  Marketing page: what Skillcheck does, install command, demo result card.
+
+/login
+  Auth page.
+
+/onboarding
+  Shows setup commands and asks user to create first token.
+
+/dashboard
+  Overview: total checks, pass/fail/verdict mix, monthly usage, active token.
+
+/tokens
+  Create, list, revoke Skillcheck tokens.
+  Show token only once after creation.
+
+/usage
+  Table of requests with date, token prefix, model, status, prompt tokens, completion tokens, cost estimate.
+
+/runs
+  Optional later: user-submitted check summaries if CLI uploads metadata.
+
+/settings
+  User profile, org settings, billing, delete account.
+
+/admin
+  Admin-only usage, errors, users, abuse controls.
+```
+
+Vercel environment variables:
+
+```bash
+NEXT_PUBLIC_API_URL=https://api.skillcheck.yourdomain.com
+AUTH_SECRET=...
+CLERK_SECRET_KEY=...
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=...
+DATABASE_URL=...
+```
+
+If you use Clerk, do not expose backend admin secrets in the browser. Only expose `NEXT_PUBLIC_*` variables that are safe for the client.
+
+## Backend: Render API
+
+Use Node.js with Fastify or Hono. Fastify is a good default for this API because plugins, hooks, and logging are straightforward.
+
+Core responsibility:
+
+```text
+Accept CLI OpenAI-compatible requests.
+Authenticate Skillcheck tokens.
+Rate limit by token and IP.
+Forward requests to upstream provider.
+Track usage and errors.
+Return OpenAI-compatible responses to the CLI.
+```
+
+Render environment variables:
+
+```bash
+PORT=10000
+DATABASE_URL=postgres://...
+REDIS_URL=redis://...
+
+FRONTEND_ORIGIN=https://app.skillcheck.yourdomain.com
+
+SKILLCHECK_TOKEN_PEPPER=long-random-secret
+ALLOW_ANONYMOUS=false
+ANONYMOUS_DAILY_LIMIT=20
+
+PROVIDER_BASE_URL=https://integrate.api.nvidia.com/v1
+PROVIDER_API_KEY=...
+DEFAULT_MODEL=qwen/qwen3-next-80b-a3b-instruct
+
+REQUEST_TIMEOUT_MS=120000
+REQUEST_DELAY_MS=5000
+MAX_ATTEMPTS=8
+MAX_RETRY_DELAY_MS=60000
+```
+
+Only the Render API should know `PROVIDER_API_KEY`.
+
+## Backend Endpoints
+
+### OpenAI-compatible CLI endpoint
+
+The CLI already expects this:
+
+```http
+POST /v1/chat/completions
+Authorization: Bearer sk_live_...
+Content-Type: application/json
+```
+
+Backend behavior:
+
+1. Parse authorization header.
+2. If token is missing:
+   - If `ALLOW_ANONYMOUS=true`, apply strict IP rate limit.
+   - Otherwise return `401`.
+3. Hash provided token and find it in `api_keys`.
+4. Check revoked status.
+5. Rate limit by key and IP.
+6. Forward request body to upstream provider.
+7. Record request usage.
+8. Return upstream response unchanged where possible.
+
+### Dashboard API endpoints
+
+```http
+GET    /health
+GET    /api/me
+GET    /api/usage
+GET    /api/tokens
+POST   /api/tokens
+DELETE /api/tokens/:id
+GET    /api/runs
+POST   /api/runs
+GET    /api/admin/users
+GET    /api/admin/usage
+POST   /api/admin/tokens/:id/revoke
+```
+
+Dashboard endpoints can live in the Render API, not Vercel serverless, to keep all auth, DB, and token logic in one backend.
+
+## Database Schema
+
+Use Postgres.
+
+```sql
+create table users (
+  id uuid primary key default gen_random_uuid(),
+  email text unique not null,
+  name text,
+  auth_provider text not null,
+  auth_provider_id text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table organizations (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text unique not null,
+  owner_user_id uuid not null references users(id),
+  created_at timestamptz not null default now()
+);
+
+create table memberships (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references organizations(id),
+  user_id uuid not null references users(id),
+  role text not null check (role in ('owner', 'admin', 'member')),
+  created_at timestamptz not null default now(),
+  unique (organization_id, user_id)
+);
+
+create table api_keys (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references organizations(id),
+  name text not null,
+  prefix text not null,
+  token_hash text unique not null,
+  last_four text not null,
+  created_by_user_id uuid not null references users(id),
+  created_at timestamptz not null default now(),
+  last_used_at timestamptz,
+  revoked_at timestamptz
+);
+
+create table usage_events (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid references organizations(id),
+  api_key_id uuid references api_keys(id),
+  request_id text,
+  path text not null,
+  model text,
+  status_code integer not null,
+  prompt_tokens integer not null default 0,
+  completion_tokens integer not null default 0,
+  total_tokens integer not null default 0,
+  estimated_cost_usd numeric(12, 6) not null default 0,
+  ip_hash text,
+  error_code text,
+  created_at timestamptz not null default now()
+);
+
+create table skill_runs (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid references organizations(id),
+  api_key_id uuid references api_keys(id),
+  skill_name text,
+  skill_format text,
+  verdict text,
+  effect_pp numeric,
+  with_skill_pass numeric,
+  no_skill_pass numeric,
+  tasks integer,
+  trials integer,
+  created_at timestamptz not null default now()
+);
+
+create table audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid references organizations(id),
+  user_id uuid references users(id),
+  action text not null,
+  metadata jsonb not null default '{}',
+  created_at timestamptz not null default now()
+);
+```
+
+## Token Design
+
+Token format:
+
+```text
+sk_live_<random>
+sk_test_<random>
+```
+
+Token generation:
+
+```text
+random = 32 bytes from crypto.randomBytes
+token = sk_live_ + base64url(random)
+prefix = first 12 visible characters
+last_four = last 4 characters
+token_hash = sha256(token + SKILLCHECK_TOKEN_PEPPER)
+```
+
+Rules:
+
+- Show token only once after creation.
+- Store only `token_hash`, prefix, and last four.
+- Never log full tokens.
+- Redact auth headers from logs.
+- Let users revoke tokens instantly.
+
+## Rate Limits
+
+Start with simple quotas:
+
+```text
+Free anonymous:
+  5 checks per IP per day
+
+Logged-in free:
+  50 checks per org per month
+  10 requests per minute
+
+Paid:
+  Plan-based monthly quota
+  30 requests per minute
+```
+
+Implement with Redis token buckets:
+
+```text
+ratelimit:ip:<hash>:day
+ratelimit:key:<api_key_id>:minute
+ratelimit:org:<org_id>:month
+```
+
+If Redis is unavailable, fail closed for anonymous traffic and fail soft for authenticated paid users with logging.
+
+## Proxy Logic
+
+For `/v1/chat/completions`:
+
+1. Accept the CLI request body.
+2. Force or override model if needed:
+
+   ```ts
+   body.model = process.env.DEFAULT_MODEL;
+   ```
+
+3. Forward to upstream provider:
+
+   ```http
+   POST ${PROVIDER_BASE_URL}/chat/completions
+   Authorization: Bearer ${PROVIDER_API_KEY}
+   ```
+
+4. Return upstream response as-is.
+5. Record usage from `response.usage`.
+
+Do not stream in v1. The current CLI sends `stream: false`, so non-streaming is enough.
+
+## Security Checklist
+
+- Store provider secrets only in Render environment variables.
+- Store dashboard auth secrets only in Vercel or Render env vars as needed.
+- Never put provider secrets in CLI, frontend code, or public docs.
+- Hash Skillcheck tokens before storing.
+- Use HTTPS only in production.
+- CORS allow only:
+
+  ```text
+  https://app.skillcheck.yourdomain.com
+  ```
+
+- CLI requests do not need browser CORS, but dashboard API calls do.
+- Log request IDs, not full payloads.
+- Redact prompts by default in production logs.
+- Add abuse controls before public launch.
+
+## Vercel Deployment Plan
+
+1. Create `skillcheck-dashboard` repo.
+2. Add `apps/web` Next.js app.
+3. Push to GitHub.
+4. Import repo in Vercel.
+5. Set root directory to `apps/web`.
+6. Add environment variables.
+7. Set production domain:
+
+   ```text
+   app.skillcheck.yourdomain.com
+   ```
+
+8. Add dashboard pages.
+9. Add auth.
+10. Add API token UI.
+
+Official note: Vercel environment variables are configured outside source code and apply to new deployments, not old deployments: https://vercel.com/docs/projects/environment-variables
+
+## Render Deployment Plan
+
+1. Add `apps/api` Node service.
+2. Add `Dockerfile` or simple Node build/start commands.
+3. Create Render Web Service from GitHub repo.
+4. Set root directory to `apps/api`.
+5. Set build command:
+
+   ```bash
+   npm install && npm run build
+   ```
+
+6. Set start command:
+
+   ```bash
+   npm run start
+   ```
+
+7. Add Render Postgres.
+8. Add Redis/Key Value.
+9. Add environment variables.
+10. Set production domain:
+
+    ```text
+    api.skillcheck.yourdomain.com
+    ```
+
+Official notes:
+
+- Render environment variables are configured per service: https://render.com/docs/configure-environment-variables/
+- Render Postgres can host the production database: https://render.com/docs/postgresql
+
+## MVP Build Order
+
+### Phase 1: Working Proxy
+
+Goal: CLI can run against your backend.
+
+- Create `apps/api`.
+- Implement `GET /health`.
+- Implement `POST /v1/chat/completions`.
+- Add provider forwarding.
+- Add request timeout and retry.
+- Deploy API to Render.
+- Run:
+
+  ```bash
+  skillcheck setup
+  skillcheck check path/to/SKILL.md
+  ```
+
+### Phase 2: Token Auth
+
+Goal: users need a Skillcheck token.
+
+- Add Postgres.
+- Add `api_keys` table.
+- Add token generation endpoint.
+- Verify `Authorization: Bearer ...`.
+- Add usage logging.
+- Add revoke endpoint.
+
+### Phase 3: Dashboard
+
+Goal: users can self-serve.
+
+- Create `apps/web`.
+- Add auth.
+- Add onboarding page.
+- Add create token page.
+- Add usage page.
+- Deploy to Vercel.
+
+### Phase 4: Abuse and Billing
+
+Goal: safe public launch.
+
+- Add Redis rate limits.
+- Add org monthly quotas.
+- Add admin dashboard.
+- Add Stripe subscriptions.
+- Add email alerts for quota exceeded and suspicious usage.
+
+### Phase 5: Run History
+
+Goal: dashboard becomes useful beyond API keys.
+
+- Add optional CLI metadata upload.
+- Store `skill_runs`.
+- Show verdict trend by skill.
+- Show helps/placebo/harms counts.
+- Add shareable run page.
+
+## Suggested Backend File Structure
+
+```text
+apps/api/src/
+  index.ts
+  env.ts
+  db.ts
+  auth/
+    tokens.ts
+    middleware.ts
+  routes/
+    health.ts
+    chat-completions.ts
+    tokens.ts
+    usage.ts
+    runs.ts
+    admin.ts
+  services/
+    provider.ts
+    rate-limit.ts
+    usage.ts
+    audit.ts
+  lib/
+    hash.ts
+    errors.ts
+    logger.ts
+```
+
+## Suggested Frontend File Structure
+
+```text
+apps/web/app/
+  page.tsx
+  login/page.tsx
+  onboarding/page.tsx
+  dashboard/page.tsx
+  tokens/page.tsx
+  usage/page.tsx
+  runs/page.tsx
+  settings/page.tsx
+  admin/page.tsx
+
+apps/web/components/
+  AppShell.tsx
+  UsageChart.tsx
+  TokenTable.tsx
+  CreateTokenDialog.tsx
+  CopyCommand.tsx
+  RunCard.tsx
+```
+
+## MVP API Pseudocode
+
+```ts
+app.post('/v1/chat/completions', async (req, reply) => {
+  const token = getBearerToken(req.headers.authorization);
+  const auth = await authenticateTokenOrAnonymous(token, req.ip);
+
+  await rateLimit(auth);
+
+  const startedAt = Date.now();
+  const upstream = await fetch(`${env.PROVIDER_BASE_URL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${env.PROVIDER_API_KEY}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      ...req.body,
+      model: env.DEFAULT_MODEL,
+      stream: false
+    })
+  });
+
+  const text = await upstream.text();
+  await recordUsage({
+    auth,
+    statusCode: upstream.status,
+    responseText: text,
+    latencyMs: Date.now() - startedAt
+  });
+
+  reply
+    .status(upstream.status)
+    .header('content-type', upstream.headers.get('content-type') ?? 'application/json')
+    .send(text);
+});
+```
+
+## What To Build First
+
+Build this order:
+
+1. Render API with `/health`.
+2. Render API `/v1/chat/completions` proxy.
+3. Point local CLI to Render API with `skillcheck setup`.
+4. Add Postgres token table.
+5. Add dashboard token creation.
+6. Add usage logging.
+7. Add rate limits.
+8. Add billing/admin later.
+
+Do not start with billing or a polished dashboard. First prove:
+
+```text
+user installs CLI -> runs setup -> checks skill -> backend records usage
+```
+
+That is the real MVP.

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -1,0 +1,15 @@
+# Skillcheck dashboard
+
+A single static file (`index.html`) where a user pastes their Skillcheck API URL and gets the commands to start using the CLI, a connection test, and an in-browser "with vs without skill" preview.
+
+```bash
+# open it directly
+xdg-open index.html        # macOS: open index.html  ·  Windows: start index.html
+
+# or serve it
+npx --yes serve .
+```
+
+Nothing to build or configure — the API URL and optional token are entered at runtime and stored in the browser's localStorage.
+
+The live preview calls `POST <apiUrl>/chat/completions`, so the API must allow the page's origin via CORS. The bundled `../nvidia-proxy` already returns `access-control-allow-origin: *`, so the preview works even from `file://`. See [`../../dashboard.md`](../../dashboard.md) for the full write-up and [`../../docs/skillcheck-cloud.md`](../../docs/skillcheck-cloud.md) for the API contract.

--- a/examples/dashboard/index.html
+++ b/examples/dashboard/index.html
@@ -1,70 +1,3 @@
-# Skillcheck Dashboard
-
-A zero-backend, single-file dashboard where a user **pastes their Skillcheck API URL** (and an optional token), and immediately gets everything they need to **start using `skillcheck`**: the exact CLI commands wired to their URL, a one-click connection test, and an in-browser "with vs without skill" preview to confirm the pipe works before they ever touch the terminal.
-
-It is plain HTML/CSS/JS — no build step, no framework, no server of its own. All settings live in the browser's `localStorage`; the token is only ever sent to the API URL the user pasted. The ready-to-open file is committed at [`examples/dashboard/index.html`](examples/dashboard/index.html) and the full source is reproduced at the bottom of this document.
-
-## What it does
-
-1. **Connect** — paste the Skillcheck API URL (e.g. `https://api.yourdomain.com/v1`) and an optional `sk_live_…` token. The URL is normalized exactly like `skillcheck setup` (a bare host becomes `…/v1`). **Test connection** pings `GET <origin>/health` and shows a live status badge.
-2. **Start using skillcheck** — the page renders copy-paste commands personalized with the saved URL/token:
-   - `npm install -g @sx4im/skillcheck`
-   - `export SKILLCHECK_API_URL=…` (plus `export SKILLCHECK_TOKEN=…` only when a token was entered)
-   - the interactive `skillcheck setup` equivalent
-   - `skillcheck check path/to/SKILL.md`
-3. **Quick check in the browser** *(optional preview)* — paste a skill body and a task; the dashboard calls `POST <apiUrl>/chat/completions` twice (one arm with the skill injected as a system message, one without) and shows both outputs side by side, plus the prompt-token overhead of injecting the skill. The arm construction mirrors the CLI runner (`packages/cli/src/run.ts`).
-
-## Run it
-
-The dashboard is a static file. Pick whichever is easiest:
-
-```bash
-# 1. Just open it (works from file:// because the bundled proxy returns CORS *)
-xdg-open examples/dashboard/index.html      # macOS: open …, Windows: start …
-
-# 2. Serve it locally
-npx --yes serve examples/dashboard          # then visit the printed URL
-
-# 3. Deploy it static (Vercel / Netlify / GitHub Pages / S3)
-#    Upload examples/dashboard/index.html as-is. There is nothing to configure at
-#    build time — the user supplies the API URL at runtime in the browser.
-```
-
-Because every setting is entered at runtime and stored client-side, the same deployed file serves every user; there are no per-deploy environment variables.
-
-## How the paste-URL flow works
-
-- The API URL is validated and normalized in the browser the same way the CLI does in `packages/cli/src/config.ts`: trim trailing slashes, require `http(s)://`, and default a path-less host to `/v1`.
-- It is saved to `localStorage` under `skillcheck.apiUrl`; the optional token under `skillcheck.token`. This is the browser-side mirror of the CLI config the user would otherwise create with `skillcheck setup`.
-- Pasting the URL here does **not** write the CLI's `~/.config/skillcheck/config.json`; the dashboard hands the user the `skillcheck setup` / `export` commands that do. The dashboard and the CLI agree on the same URL contract, so a URL that works in one works in the other.
-
-## What a backend must expose
-
-The dashboard talks to the same OpenAI-compatible contract the CLI expects:
-
-- `POST <apiUrl>/chat/completions` — used by the live preview. Body is OpenAI-shaped (`model`, `messages`, `temperature`, `max_tokens`, `stream:false`); `Authorization: Bearer <token>` is sent when a token is set.
-- `GET <origin>/health` — optional; used only by **Test connection**. If it is absent, the URL is still saved and the user is told to verify with a real check.
-- **CORS**: the browser preview needs the API to allow the dashboard's origin. The bundled proxy in [`examples/nvidia-proxy`](examples/nvidia-proxy) already responds with `access-control-allow-origin: *` and handles the `OPTIONS` preflight, so the preview works out of the box (including from `file://`). A production Skillcheck Cloud API should allow your dashboard's real origin instead of `*`. See [`docs/skillcheck-cloud.md`](docs/skillcheck-cloud.md) for the API contract and the minimal proxy.
-
-If a browser call is blocked by CORS, the dashboard says so and points the user to run the check from the CLI, which is not subject to browser CORS.
-
-## Preview vs. the real verdict
-
-The in-browser preview is deliberately a **single, ungraded trial** so it stays cheap and instant. It shows the qualitative contrast and proves the connection — it is **not** the measurement. The real verdict comes from the CLI, which generates *N* independent tasks, runs *K* trials per arm, grades blind, and reports an effect with a bootstrap confidence interval. See [`METHODOLOGY.md`](METHODOLOGY.md), and run:
-
-```bash
-skillcheck check path/to/SKILL.md --tasks 10 --trials 3
-```
-
-## Going further: hosted multi-user backend
-
-This dashboard intentionally has no accounts, tokens, billing, or usage tracking — it is the fastest path from "I have an API URL" to "I'm running checks." When you want a hosted product (sign-up, self-serve token creation, per-org rate limits, usage and run history), the full backend architecture, database schema, endpoints, and phased build order live in [`docs/skillcheck-cloud-build-plan.md`](docs/skillcheck-cloud-build-plan.md).
-
-## Source
-
-The complete dashboard follows. It is identical to [`examples/dashboard/index.html`](examples/dashboard/index.html) — copy this block into an `index.html` and open it, or just open the committed file.
-
-````html
 <!doctype html>
 <html lang="en">
   <head>
@@ -458,5 +391,3 @@ The complete dashboard follows. It is identical to [`examples/dashboard/index.ht
     </script>
   </body>
 </html>
-````
-

--- a/packages/cli/src/adapters/nvidia-nim.ts
+++ b/packages/cli/src/adapters/nvidia-nim.ts
@@ -120,7 +120,7 @@ export class NvidiaNimClient {
   private readonly maxAttempts: number;
   private readonly maxRetryDelayMs: number;
 
-  constructor(config: NvidiaConfig) {
+  constructor(config: NvidiaConfig, options: { defaultHeaders?: Record<string, string> } = {}) {
     this.requestDelayMs = config.requestDelayMs;
     this.maxAttempts = config.maxAttempts;
     this.maxRetryDelayMs = config.maxRetryDelayMs;
@@ -128,7 +128,8 @@ export class NvidiaNimClient {
       apiKey: config.apiKey,
       baseURL: config.baseUrl,
       maxRetries: 0,
-      timeout: config.timeoutMs
+      timeout: config.timeoutMs,
+      defaultHeaders: options.defaultHeaders
     });
   }
 

--- a/packages/cli/src/cache.ts
+++ b/packages/cli/src/cache.ts
@@ -3,9 +3,26 @@ import path from 'node:path';
 import { hashJson } from './hash.js';
 
 export class JsonCache {
-  constructor(private readonly rootDir = '.cache/skillcheck') {}
+  constructor(
+    private readonly rootDir = '.cache/skillcheck',
+    private readonly enabled = true
+  ) {}
+
+  /**
+   * A cache that never reads or writes: every `getOrSet` calls its factory.
+   * Used by `verify`, which must independently re-query the model rather than
+   * replay the original run's cached outputs (otherwise verification is a
+   * tautology on the machine that produced the result).
+   */
+  static disabled(): JsonCache {
+    return new JsonCache(undefined, false);
+  }
 
   async getOrSet<T>(namespace: string, keyParts: unknown, factory: () => Promise<T>): Promise<T> {
+    if (!this.enabled) {
+      return factory();
+    }
+
     const key = hashJson(keyParts);
     const dir = path.join(this.rootDir, namespace);
     const file = path.join(dir, `${key}.json`);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,8 +36,10 @@ async function ensureCloudConfigured(force = false): Promise<void> {
     try {
       const apiUrl = normalizeApiUrl(value);
       const current = loadUserConfig();
-      const filePath = saveUserConfig({ ...current, apiUrl });
-      console.log(`Saved Skillcheck API URL to ${filePath}\n`);
+      const keyInput = await promptText('Skillcheck API key (press Enter to skip): ');
+      const next = keyInput ? { ...current, apiUrl, token: keyInput } : { ...current, apiUrl };
+      const filePath = saveUserConfig(next);
+      console.log(`Saved Skillcheck settings to ${filePath}\n`);
       return;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/eval.ts
+++ b/packages/cli/src/eval.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { NvidiaNimClient } from './adapters/nvidia-nim.js';
@@ -110,7 +111,10 @@ export async function evalSkill(options: EvalOptions): Promise<unknown> {
   const skill = await normalizeSkill(options.inputPath);
   const baseConfig = loadNvidiaConfig();
   const config = applyModelOverrides(baseConfig, options);
-  const client = new NvidiaNimClient(config);
+  // One run id per evalSkill call. The hosted proxy meters by distinct run id, so
+  // every model call in this run shares it and the whole check counts as one run.
+  const runId = randomUUID();
+  const client = new NvidiaNimClient(config, { defaultHeaders: { 'x-skillcheck-run': runId } });
   const cache = new JsonCache();
 
   const tasks = options.taskSuite

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -29,7 +29,12 @@ async function runOne(
   cache: JsonCache
 ): Promise<TrialOutput> {
   const messages = messagesForArm(skill, task, arm === 'with_skill');
-  const response = await cache.getOrSet('runner', { model: config.runnerModel, temperature: 0.7, maxTokens: 1200, messages }, () =>
+  // `trial` MUST be part of the cache key. Without it, every trial for the same
+  // (skill, task, arm) produces identical `messages` and therefore the same key,
+  // so trials 2..K silently read trial 1's cached output. That collapses K
+  // independent stochastic samples (temperature 0.7) into one replicated K times
+  // and makes the paired-bootstrap CI ~sqrt(K) too narrow (pseudo-replication).
+  const response = await cache.getOrSet('runner', { model: config.runnerModel, temperature: 0.7, maxTokens: 1200, promptVersion: 1, trial, messages }, () =>
     client.complete({
       model: config.runnerModel,
       messages,

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -67,8 +67,8 @@ export async function promptText(question: string): Promise<string> {
 
 export function printSetupIntro(): void {
   console.log(`${blue('First-time setup')}`);
-  console.log('Paste your Skillcheck API URL, then Skillcheck will open the file picker.');
-  console.log(`${dim('Example:')} https://api.yourdomain.com/v1\n`);
+  console.log('Paste your Skillcheck API URL and API key from the dashboard, then Skillcheck opens the file picker.');
+  console.log(`${dim('Example URL:')} https://your-app.vercel.app/api\n`);
 }
 
 export function supportedSkillFilesText(): string {
@@ -363,6 +363,9 @@ export function formatResultCard(result: unknown, outputPath?: string): string {
 
 export function sanitizeCliError(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
+  if (/quota[_ ]?exceeded|payment required|free .*runs|\b402\b/i.test(raw)) {
+    return raw.replace(/^\d+\s+/, '').replace(/NVIDIA[_ -]?NIM|NVIDIA/gi, 'Skillcheck Cloud');
+  }
   if (/api[_ -]?key|credential|unauthorized|authentication|401/i.test(raw)) {
     return 'Skillcheck Cloud is not connected for this workspace. Please try again later or contact the workspace owner.';
   }

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { NvidiaNimClient } from './adapters/nvidia-nim.js';
 import { JsonCache } from './cache.js';
@@ -62,8 +63,11 @@ export async function verifyResult(options: VerifyOptions): Promise<unknown> {
     reproducibility: { task_suite_path: string };
   };
   const config = loadNvidiaConfig();
-  const client = new NvidiaNimClient(config);
-  const cache = new JsonCache();
+  const client = new NvidiaNimClient(config, { defaultHeaders: { 'x-skillcheck-run': randomUUID() } });
+  // Verification must be an independent re-measurement, so it bypasses the cache.
+  // Reusing the shared on-disk cache would replay the original run's outputs and
+  // make `verify` trivially pass on the machine that produced the result.
+  const cache = JsonCache.disabled();
   const skill = await normalizeSkill(published.skill.source);
   const tasks = parseTasks(await readFile(published.reproducibility.task_suite_path, 'utf8')).slice(0, options.sample);
   const outputs = await runTrials(skill, tasks, published.config.trials, config, client, cache);

--- a/packages/cli/test/cache.test.ts
+++ b/packages/cli/test/cache.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { JsonCache } from '../src/cache.js';
+
+describe('JsonCache', () => {
+  it('reuses a stored value for the same key', async () => {
+    const cacheDir = await mkdtemp(path.join(tmpdir(), 'skillcheck-cache-'));
+    const cache = new JsonCache(cacheDir);
+    let calls = 0;
+    const factory = async () => {
+      calls += 1;
+      return calls;
+    };
+
+    const first = await cache.getOrSet('ns', { key: 1 }, factory);
+    const second = await cache.getOrSet('ns', { key: 1 }, factory);
+
+    expect(first).toBe(1);
+    expect(second).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  it('recomputes for different keys', async () => {
+    const cacheDir = await mkdtemp(path.join(tmpdir(), 'skillcheck-cache-'));
+    const cache = new JsonCache(cacheDir);
+    let calls = 0;
+    const factory = async () => {
+      calls += 1;
+      return calls;
+    };
+
+    await cache.getOrSet('ns', { key: 1 }, factory);
+    await cache.getOrSet('ns', { key: 2 }, factory);
+
+    expect(calls).toBe(2);
+  });
+
+  it('disabled() always calls the factory and never reuses a value', async () => {
+    // This is what `verify` relies on: every call hits the model fresh.
+    const cache = JsonCache.disabled();
+    let calls = 0;
+    const factory = async () => {
+      calls += 1;
+      return calls;
+    };
+
+    const first = await cache.getOrSet('ns', { key: 1 }, factory);
+    const second = await cache.getOrSet('ns', { key: 1 }, factory);
+
+    expect(first).toBe(1);
+    expect(second).toBe(2);
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { NvidiaNimClient } from '../src/adapters/nvidia-nim.js';
+import { JsonCache } from '../src/cache.js';
+import type { NvidiaConfig } from '../src/env.js';
+import { runTrials } from '../src/run.js';
+import type { GeneratedTask, NormalizedSkill } from '../src/types.js';
+
+const config = {
+  baseUrl: 'https://example.test',
+  apiKey: 'test',
+  timeoutMs: 1000,
+  requestDelayMs: 0,
+  maxAttempts: 8,
+  maxRetryDelayMs: 60000,
+  generatorModel: 'generator',
+  graderModel: 'grader',
+  runnerModel: 'runner'
+} satisfies NvidiaConfig;
+
+const skill: NormalizedSkill = {
+  name: 'Example Skill',
+  sourcePath: 'SKILL.md',
+  format: 'SKILL.md',
+  instructions: 'Always do the thing carefully.',
+  domain: 'example domain',
+  assets: [],
+  versionHash: 'hash'
+};
+
+const tasks: GeneratedTask[] = [
+  { id: 't001', prompt: 'Do the task', criterionType: 'rubric', criterion: 'Output satisfies the task.' }
+];
+
+describe('runTrials trial independence', () => {
+  it('queries the model once per trial per arm instead of replaying a cached trial', async () => {
+    // Regression guard for the cache-collapse bug: the runner cache key must
+    // include `trial`. Before the fix the model was called twice total (one
+    // cache miss per arm, then trials 2..K read trial 1 back). After the fix it
+    // is called trials x arms times, with a distinct output per trial.
+    const cacheDir = await mkdtemp(path.join(tmpdir(), 'skillcheck-run-cache-'));
+    let calls = 0;
+    const client = {
+      complete: async () => {
+        calls += 1;
+        return {
+          content: `output-${calls}`,
+          model: 'runner',
+          usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 }
+        };
+      }
+    } as unknown as NvidiaNimClient;
+
+    const outputs = await runTrials(skill, tasks, 3, config, client, new JsonCache(cacheDir));
+
+    expect(calls).toBe(6); // 1 task x 3 trials x 2 arms
+    expect(outputs).toHaveLength(6);
+
+    const withSkillOutputs = outputs.filter((output) => output.arm === 'with_skill').map((output) => output.output);
+    expect(withSkillOutputs).toHaveLength(3);
+    expect(new Set(withSkillOutputs).size).toBe(3); // trials are not collapsed into one
+
+    const noSkillOutputs = outputs.filter((output) => output.arm === 'no_skill').map((output) => output.output);
+    expect(new Set(noSkillOutputs).size).toBe(3);
+  });
+
+  it('serves a repeated trial from cache on a warm run', async () => {
+    // Same key (same trial) must still hit the cache, so re-running a result is
+    // reproducible on the same machine.
+    const cacheDir = await mkdtemp(path.join(tmpdir(), 'skillcheck-run-cache-'));
+    let calls = 0;
+    const client = {
+      complete: async () => {
+        calls += 1;
+        return {
+          content: `output-${calls}`,
+          model: 'runner',
+          usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 }
+        };
+      }
+    } as unknown as NvidiaNimClient;
+
+    const cache = new JsonCache(cacheDir);
+    const first = await runTrials(skill, tasks, 3, config, client, cache);
+    const second = await runTrials(skill, tasks, 3, config, client, cache);
+
+    expect(calls).toBe(6); // second run is fully cached
+    expect(second.map((output) => output.output)).toEqual(first.map((output) => output.output));
+  });
+});

--- a/packages/cli/test/ui.test.ts
+++ b/packages/cli/test/ui.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeCliError } from '../src/ui.js';
+
+describe('sanitizeCliError', () => {
+  it('surfaces a clean upgrade message for quota / 402 errors', () => {
+    const message = sanitizeCliError(
+      new Error("402 You've used all 10 free Skillcheck runs. Upgrade to keep going at https://app.example/app.html")
+    );
+    expect(message).toContain('free Skillcheck runs');
+    expect(message).toContain('Upgrade');
+    expect(message.startsWith('402')).toBe(false);
+    expect(message).not.toContain('not connected');
+  });
+
+  it('maps auth errors to a friendly connect message', () => {
+    expect(sanitizeCliError(new Error('401 Unauthorized: invalid api key'))).toMatch(/not connected/i);
+  });
+
+  it('scrubs provider branding from generic errors', () => {
+    expect(sanitizeCliError(new Error('NVIDIA NIM request timeout'))).toContain('Skillcheck Cloud');
+    expect(sanitizeCliError(new Error('NVIDIA NIM request timeout'))).not.toContain('NVIDIA');
+  });
+});


### PR DESCRIPTION
… and verify caching

Hosted product (dashboard/):
- Zero-dependency, zero-build Vercel app: static landing + dashboard (HP design per DESIGN.md) plus serverless api/ functions.
- GitHub OAuth sign-in, HMAC signed-cookie sessions, issues sk_live_ API keys.
- Metered proxy: authenticates the key, counts distinct x-skillcheck-run ids, allows FREE_RUNS (default 10) then returns HTTP 402, and forwards to the server-side NVIDIA key (never shipped to the CLI/browser).
- Stripe upgrade via Checkout + server-side confirm-on-return (no webhook).
- Upstash Redis store with in-memory fallback; smoke + proxy integration tests.
- dashboard/SETUP.md: full deploy + API-key guide for every platform.

CLI:
- eval/verify send a per-run x-skillcheck-run header so the proxy meters runs, not raw calls (NvidiaNimClient gains defaultHeaders).
- sanitizeCliError maps 402 to a friendly upgrade message.
- `skillcheck setup` now also captures the API key.

Correctness fixes (from the review):
- run.ts: include `trial` in the runner cache key so K trials are independent again. Previously trials 2..K replayed trial 1 from cache, collapsing the sample and narrowing every bootstrap CI ~1.6x (pseudo-replication).
- cache.ts/verify.ts: JsonCache.disabled() so `verify` independently re-queries the model instead of replaying the original run's cached outputs.
- Regression tests: run.test.ts, cache.test.ts, ui.test.ts.

Docs:
- dashboard.md: drop-in single-file connect page for bring-your-own-proxy users; prior backend plan moved to docs/skillcheck-cloud-build-plan.md.
- README, RELEASE-CHECKLIST, .gitignore updated for the hosted path.