### PR TITLE
chore: GitHub + npm discoverability / SEO pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to skillcheck
+
+Thanks for taking a look. This guide mirrors the Development workflow already
+documented in the README — keep changes small and testable.
+
+## Prerequisites
+
+- Node.js 20+
+- npm
+
+## Setup
+
+```bash
+npm ci
+```
+
+## Checks to run before opening a PR
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+npm test
+# optional, matches the CI coverage gate:
+npm run test:coverage
+```
+
+The test suite is offline (model adapters are mocked). You should not need API
+keys for unit/integration tests.
+
+## Scope
+
+- Prefer focused PRs that change one concern at a time.
+- Match existing style in the area you touch; don't drive-by reformat unrelated files.
+- CLI UI lives under `packages/cli/src/ui/` — keep modules modular (banner, picker,
+  step tracker, result card, menus).
+
+## Pull requests
+
+1. Branch from `main`.
+2. Make your change and run the checks above.
+3. Open a PR with a short summary of *why* the change exists and how you verified it.
+
+Issues and questions: https://github.com/sx4im/skillcheck/issues

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%E2%89%A520-brightgreen" alt="Node ≥20"></a>
 </p>
 
-**Measure whether an agent skill actually improves a model's task performance.**
+**CLI for AI agent skill testing and prompt A/B testing** — measure whether an agent
+skill actually improves a model's task performance.
 
 Most published `SKILL.md` files have never been tested. You can't tell whether they
 help your model or are just decoration. Skillcheck answers that with a controlled
-experiment instead of a vibe check.
+experiment instead of a vibe check: AI agent evaluation with blind grading, not
+anecdotes.
 
 Point it at any Markdown skill file and it runs an A/B test: it generates fresh tasks
 for the skill's declared domain, has the model solve every task **with** and
@@ -53,6 +55,7 @@ $ skillcheck
 
 - [Install](#install)
 - [Quick start](#quick-start)
+- [Why skillcheck](#why-skillcheck)
 - [How it works](#how-it-works)
 - [Architecture](#architecture)
 - [Commands](#commands)
@@ -109,6 +112,18 @@ Fully headless (CI, scripts) — set the key via environment variable:
 export SKILLCHECK_TOKEN=chk_live_...
 skillcheck check ./SKILL.md --tasks 5 --trials 3 --json
 ```
+
+## Why skillcheck
+
+- **Ship skills with evidence** — before you publish a Claude Code, Codex, or Cursor
+  `SKILL.md`, know whether it helps the model or just adds tokens.
+- **Prompt A/B testing in one command** — compare with-skill vs without-skill arms on
+  the same tasks, with blind grading so the grader never sees which arm wrote the answer.
+- **CI-friendly LLM eval** — `--json` / `--output` for scripts and pipelines; hosted
+  mode or bring-your-own-key across OpenAI, Anthropic, Gemini, Groq, Mistral, OpenRouter,
+  and NVIDIA NIM.
+- **Effect size, not vibes** — bootstrap confidence intervals and a 0–100 satisfaction
+  score so you can tell a real lift from noise. Details in [`METHODOLOGY.md`](METHODOLOGY.md).
 
 ## How it works
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are applied to the latest published release of `@sx4im/skillcheck`
+on npm. Older versions are not backported unless a critical issue warrants it.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report privately via one of:
+
+1. **GitHub Security Advisories** — use
+   [Report a vulnerability](https://github.com/sx4im/skillcheck/security/advisories/new)
+   on this repository (preferred).
+2. **Email the maintainer** — contact listed on
+   [https://github.com/sx4im](https://github.com/sx4im) if advisory filing is unavailable.
+
+Include enough detail to reproduce the issue (affected version, environment, and
+steps). You should receive an acknowledgement within a few days; we will
+coordinate disclosure after a fix is available when possible.
+
+## Scope notes
+
+- API keys and tokens stored by the CLI under `~/.config/skillcheck/` are local
+  credentials — treat them like secrets and never commit them.
+- The hosted dashboard proxies model calls; do not send production secrets into
+  public issue trackers or sample skills.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sx4im/skillcheck",
   "version": "0.9.7",
-  "description": "Measure whether agent skills improve task performance.",
+  "description": "CLI for AI agent skill testing and prompt A/B testing — measure whether a SKILL.md improves LLM task performance.",
   "type": "module",
   "license": "MIT",
   "author": "sx4im",
@@ -12,14 +12,24 @@
   "bugs": {
     "url": "https://github.com/sx4im/skillcheck/issues"
   },
-  "homepage": "https://github.com/sx4im/skillcheck#readme",
+  "homepage": "https://dashboard-skillcheck.vercel.app/",
   "keywords": [
-    "agents",
-    "ai",
-    "benchmark",
     "cli",
+    "llm",
+    "ai-agent",
+    "ai-agents",
+    "agent-skills",
+    "skill-testing",
+    "llm-eval",
+    "evals",
     "evaluation",
-    "skills"
+    "prompt-engineering",
+    "prompt-testing",
+    "ab-testing",
+    "benchmark",
+    "testing",
+    "typescript",
+    "nodejs"
   ],
   "bin": {
     "skillcheck": "dist/bin/skillcheck.js"


### PR DESCRIPTION
## Summary

Discoverability/SEO pass for https://github.com/sx4im/skillcheck and `@sx4im/skillcheck`. **No source, CLI, or dependency changes** — metadata, README content additions, and community health files only.

### Phase 1 — Research (basis for changes)

**GitHub (2026 guides / docs):** ranking blends text relevance (repo name, About description, topics, README) with popularity/freshness (stars, forks, recent activity). Topics (≤20) and a keyword-rich About are high-leverage. Community profile files (README, LICENSE, CONTRIBUTING, SECURITY, optional CoC) improve the community standards checklist ([GitHub docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories)).

**npm (current official docs):** default search is OpenSearch keyword matching on **title, description, README, keywords** — subjective quality/popularity/maintenance scores are no longer the default ranking ([npm docs](https://docs.npmjs.com/searching-for-and-choosing-packages-to-download), Feb 2025). Sortable dimensions still include downloads, dependents, last published. So keyword coverage in `description` + `keywords` + README matters most for match; `repository` / `homepage` / `bugs` remain important for trust and packaging UX.

**Comparable repos (patterns only):** promptfoo / deepeval use keyword-dense About lines, product homepage URLs, and topic stacks mixing `llm-eval` / `evaluation` / `prompt-engineering` with stack tags. openai/evals and autoevals often under-use topics — we treated that as a gap to avoid, not a model to copy.

### Phase 2 — GitHub repo settings (applied via `gh`, live on the repo)

- **About** set to a one-line pitch aligned with README/npm description (not a raw URL).
- **Website** set to `https://dashboard-skillcheck.vercel.app/` (note: that host currently 307s to `www.skillcheck.page`).
- **Topics** replaced (20): fixed typo `benchamrk` → `benchmark`; dropped niche/redundant tags (`openclaw-skills`, `agentic-workflow`, `llm-evaluation-benchmark`, etc.); added peer-aligned terms (`llm`, `llm-eval`, `prompt-engineering`, `evals`, `testing`, `nodejs`, `developer-tools`).
- **Social preview:** `open_graph_image_url` is **null** — flagged only; no image generated.
- **Freshness:** `main` tip commit is `f84fdd7` (2026-07-25). Not abandoned; no fake/forced freshness commits.

### Phase 3 — README SEO (this PR)

- Badges (npm version, downloads, CI, license, Node ≥20) were **already present** — left as-is.
- Opening lines rewritten lightly to include search terms: CLI, AI agent skill testing, prompt A/B testing, AI agent evaluation. Result-card example untouched.
- Added **Why skillcheck** (4 real use-case bullets). Commands / Effort / Reading the result untouched.
- Link check: `METHODOLOGY.md` ✅; README points at `dashboard/README.md` ✅ (there is no `dashboard/SETUP.md` — not introduced).

### Phase 4 — `package.json` metadata only (this PR)

- Expanded `keywords` for OpenSearch match coverage.
- Aligned `description` with GitHub About.
- Set `homepage` to dashboard URL; confirmed `repository`, `bugs`, `author`, `license`, `engines.node: ">=20"`.
- **No** script/dependency/`files`/`bin` changes.

### Phase 5 — Community health (this PR)

- Added `CONTRIBUTING.md` from the real `npm ci` / lint / typecheck / test workflow.
- Added `SECURITY.md` with private reporting via GitHub Security Advisories.
- **Skipped `CODE_OF_CONDUCT.md`** (optional for solo/early-stage; left for maintainer call).

## Test plan

- [ ] Confirm PR diff only touches `README.md`, `package.json`, `CONTRIBUTING.md`, `SECURITY.md`
- [ ] Spot-check GitHub About / website / topics on the repo page
- [ ] After merge, re-check community profile % (CONTRIBUTING + SECURITY should register)
- [ ] Optionally set a Social preview image under Settings → General
- [ ] Next npm publish will pick up new `description` / `keywords` / `homepage` (metadata-only; no version bump in this PR)

## Explicit non-touch confirmation

No files under `packages/`, `dashboard/` (app code), `fixtures/`, `corpus/`, or `results/` were modified.


Made with [Cursor](https://cursor.com)